### PR TITLE
Feature: Desarrollo del Capítulo 7

### DIFF
--- a/historias/capitulo6.html
+++ b/historias/capitulo6.html
@@ -71,7 +71,11 @@
 
     <footer>
         <p>Fin del Capítulo 6. Nuevos aliados y antiguos secretos marcan el camino de Elara.</p>
-        <p><a href="../index.html">Volver al Índice</a> | <a href="capitulo5.html">Capítulo Anterior</a> | <a href="capitulo7.html">Siguiente Capítulo (Próximamente)</a></p>
+        <p>
+            <a href="capitulo5.html">Capítulo Anterior</a> |
+            <a href="../index.html">Volver al Índice</a> |
+            <a href="capitulo7.html">Siguiente Capítulo: Secretos Revelados y Decisiones Críticas</a>
+        </p>
     </footer>
 
     <!-- El Modal Genérico (copiado para funcionalidad en esta página) -->

--- a/historias/capitulo7.html
+++ b/historias/capitulo7.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Capítulo 7: Secretos Revelados y Decisiones Críticas - Novela Multidimensional</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body>
+    <header>
+        <h1>Capítulo 7: Secretos Revelados y Decisiones Críticas</h1>
+        <p><a href="../index.html">Volver al Índice</a></p>
+    </header>
+
+    <nav class="navegacion-interna">
+        <ul>
+            <li><a href="#tiempo-presente-cap7">Presente Cap. 7</a></li>
+            <li><a href="#tiempo-pasado-cap7">Pasado Iluminador</a></li>
+            <li><a href="#tiempo-futuro-cap7">Futuro Decisivo</a></li>
+        </ul>
+    </nav>
+
+    <main>
+        <article>
+            <section id="tiempo-presente-cap7" class="linea-temporal presente">
+                <h2>Presente: El Corazón de la Biblioteca</h2>
+                <p>
+                    <a href='../personajes/heroe_principal.html' class='activador-modal tooltip' data-modal-titulo='Elara' data-modal-parrafo1='Concentrada en la búsqueda de conocimiento para enfrentar a Kael.' data-modal-parrafo2='La Biblioteca Olvidada es su mayor esperanza.'>Elara<span class='tooltip-texto'>La protagonista.</span></a> y <a href='../personajes/silas_archivista.html' class='activador-modal tooltip' data-modal-titulo='Silas, el Archivista' data-modal-parrafo1='Guardián de la Biblioteca Olvidada y ahora un cauto aliado.' data-modal-parrafo2='Su conocimiento es vital para descifrar los secretos.'>Silas<span class='tooltip-texto'>El Archivista del Yermo.</span></a> trabajan febrilmente en la <a href='../lugares/biblioteca_olvidada.html' class='activador-modal tooltip' data-modal-titulo='Biblioteca Olvidada' data-modal-parrafo1='Un tesoro de conocimiento antiguo, lleno de secretos y peligros.' data-modal-parrafo2='Sus pasillos susurrantes guardan respuestas. '>Biblioteca Olvidada<span class='tooltip-texto'>El centro del saber perdido.</span></a>. El ambiente es de polvo ancestral, el susurro constante de páginas antiguas y la luz parpadeante de cristales luminosos o antorchas que Silas mantiene.
+                </p>
+                <p>
+                    Tras días de investigación, superan un complejo acertijo o descifran un código en un manuscrito aparentemente anodino. Esto les da acceso a una sección oculta de la biblioteca, o a un cofre sellado que contiene un rollo o tableta particularmente importante.
+                </p>
+                <p>
+                    <strong>La Revelación Clave:</strong> Descubren la verdad sobre el artefacto de Elara: [El artefacto es uno de varios "Corazones de Cronos", fragmentos de un dispositivo mayor capaz de estabilizar o desestabilizar el flujo temporal, creado por una civilización anterior para protegerse de entidades extradimensionales. Kael busca reunirlos para obtener un poder divino o para liberar a estas entidades]. O quizás, una profecía detallada sobre el "Despertar de las Sombras", que no solo involucra a Kael, sino a una amenaza cósmica mayor que él solo desea controlar o desatar.
+                </p>
+                <p>
+                    Las implicaciones de esta revelación son enormes. Elara y Silas discuten el significado y el peligro inminente. El consejo de <a href='../personajes/lyra.html' class='activador-modal tooltip' data-modal-titulo='Lyra' data-modal-parrafo1='Su sabiduría podría ofrecer una nueva perspectiva sobre la revelación.'>Lyra<span class='tooltip-texto'>La sabia consejera.</span></a> es recordado, quizás una de sus leyendas ahora cobra un nuevo y aterrador sentido.
+                </p>
+                <p>
+                    <strong>La Decisión Crítica:</strong> Basándose en la revelación, deben decidir su próximo curso de acción: ¿Intentar encontrar los otros Corazones de Cronos antes que Kael? ¿Buscar la manera de destruir el artefacto de Elara, a pesar de su poder y el riesgo que ello conlleve? ¿O prepararse para un enfrentamiento directo con <a href='../personajes/kael.html' class='activador-modal tooltip' data-modal-titulo='Kael' data-modal-parrafo1='El antagonista, cuyos planes son más vastos de lo que imaginaban.'>Kael<span class='tooltip-texto'>El Perseguidor de Sombras.</span></a>, ahora con un mayor entendimiento de sus objetivos?
+                </p>
+                <p>
+                    Justo cuando toman una decisión (o están a punto de hacerlo), un temblor sacude la Biblioteca. Una señal mágica o una perturbación en el artefacto les indica que <a href='../personajes/acolito_kael.html' class='activador-modal tooltip' data-modal-titulo='Acólito Sombrío' data-modal-parrafo1='El persistente agente de Kael.'>el Acólito<span class='tooltip-texto'>El sirviente de Kael.</span></a> o el propio Kael están cerca, o han detectado su actividad y el poder liberado al descifrar el secreto.
+                </p>
+                <p class="navegacion-seccion"><a href="#tiempo-pasado-cap7">Siguiente: Pasado Iluminador</a> | <a href="#tiempo-futuro-cap7">Saltar a: Futuro Decisivo</a></p>
+            </section>
+
+            <section id="tiempo-pasado-cap7" class="linea-temporal flashback">
+                <h2>Pasado Iluminador: El Origen del Secreto</h2>
+                <p>
+                    Un flashback directamente ligado a la Revelación Clave. Si fue sobre los Corazones de Cronos, se muestra a los creadores originales (quizás una civilización avanzada y pacífica) diseñando estos artefactos. Se ve a <a href='../personajes/ancestro_elara.html' class='activador-modal tooltip' data-modal-titulo='Aerion el Guardián' data-modal-parrafo1='O un contemporáneo suyo de la orden de los Guardianes.'>Aerion<span class='tooltip-texto'>El Guardián original.</span></a> (o sus precursores) recibiendo uno de los Corazones y jurando protegerlo. Se muestra el primer uso catastrófico o la razón por la que fueron dispersados y ocultados.
+                </p>
+                <p>
+                    Si la revelación fue sobre Kael y la profecía, el flashback podría mostrar un evento crucial en el pasado de Kael: el momento en que descubrió la existencia de la profecía, su primer intento fallido de obtener el poder que anhela, o una traición que lo corrompió y lo puso en su actual senda oscura.
+                </p>
+                <p>
+                    Este flashback debe dar un peso emocional y un contexto histórico profundo a lo que Elara y Silas acaban de descubrir, subrayando la importancia de su misión.
+                </p>
+                <p class="navegacion-seccion"><a href="#tiempo-presente-cap7">Volver al Presente</a> | <a href="#tiempo-futuro-cap7">Siguiente: Futuro Decisivo</a></p>
+            </section>
+
+            <section id="tiempo-futuro-cap7" class="linea-temporal premonicion">
+                <h2>Futuro Decisivo: Las Consecuencias del Camino Elegido</h2>
+                <p>
+                    Una visión fugaz y potente, directamente influenciada por la Decisión Crítica tomada por Elara y Silas en el presente:
+                </p>
+                <p>
+                    Si deciden buscar otro Corazón de Cronos, la visión podría mostrarles un entorno nuevo y extremadamente peligroso (un templo sumergido, una ciudadela flotante, el corazón de un volcán) con un guardián formidable protegiéndolo.
+                </p>
+                <p>
+                    Si deciden enfrentarse a Kael de una manera específica (basada en la nueva información), la visión podría mostrar el éxito parcial de su plan, pero con un sacrificio inesperado (un personaje secundario importante, o una habilidad de Elara que se pierde). O podría mostrar un fracaso que los obliga a huir y replantearse toda su estrategia, quizás perdiendo la Biblioteca Olvidada en el proceso.
+                </p>
+                <p>
+                    La visión no es completamente clara, dejando espacio para la incertidumbre pero subrayando la gravedad e irreversibilidad del camino que están a punto de tomar. El futuro es maleable, pero cada elección tiene un eco poderoso.
+                </p>
+                <p class="navegacion-seccion"><a href="#tiempo-presente-cap7">Volver al Presente</a> | <a href="#tiempo-pasado-cap7">Revisitar: Pasado Iluminador</a></p>
+            </section>
+        </article>
+    </main>
+
+    <footer>
+        <p>Fin del Capítulo 7. El conocimiento adquirido exige una acción peligrosa.</p>
+        <p><a href="../index.html">Volver al Índice</a> | <a href="capitulo6.html">Capítulo Anterior</a> | <a href="capitulo8.html">Siguiente Capítulo (Próximamente)</a></p>
+    </footer>
+
+    <!-- El Modal Genérico (copiado para funcionalidad en esta página) -->
+    <div id="miModal" class="modal-contenedor">
+        <div class="modal-contenido">
+            <span class="modal-cerrar">&times;</span>
+            <h2>Título del Modal</h2>
+            <p>Contenido de ejemplo...</p>
+            <p>Más contenido aquí si es necesario.</p>
+        </div>
+    </div>
+    <script src="../js/interacciones.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Este commit introduce la estructura y el contenido de marcador de posición para el Capítulo 7, "Secretos Revelados y Decisiones Críticas".

Cambios principales:
- Creación de `historias/capitulo7.html` con secciones para el presente (investigación en la Biblioteca Olvidada, revelación clave, decisión crítica), pasado (contexto de la revelación) y futuro (consecuencias de la decisión).
- Actualización de `historias/capitulo6.html` para enlazar secuencialmente al Capítulo 7.
- Integración de activadores de modales en el Capítulo 7 para personajes y lugares relevantes.
- Inclusión de la estructura del modal y el script JS en la página del nuevo capítulo.