### PR TITLE
Feature: Desarrollo del Capítulo 8, nuevo personaje y lugar

### DIFF
--- a/historias/capitulo7.html
+++ b/historias/capitulo7.html
@@ -80,7 +80,11 @@
 
     <footer>
         <p>Fin del Capítulo 7. El conocimiento adquirido exige una acción peligrosa.</p>
-        <p><a href="../index.html">Volver al Índice</a> | <a href="capitulo6.html">Capítulo Anterior</a> | <a href="capitulo8.html">Siguiente Capítulo (Próximamente)</a></p>
+        <p>
+            <a href="capitulo6.html">Capítulo Anterior</a> |
+            <a href="../index.html">Volver al Índice</a> |
+            <a href="capitulo8.html">Siguiente Capítulo: El Camino Elegido y Sus Primeras Pruebas</a>
+        </p>
     </footer>
 
     <!-- El Modal Genérico (copiado para funcionalidad en esta página) -->

--- a/historias/capitulo8.html
+++ b/historias/capitulo8.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Capítulo 8: El Camino Elegido y Sus Primeras Pruebas - Novela Multidimensional</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body>
+    <header>
+        <h1>Capítulo 8: El Camino Elegido y Sus Primeras Pruebas</h1>
+        <p><a href="../index.html">Volver al Índice</a></p>
+    </header>
+
+    <nav class="navegacion-interna">
+        <ul>
+            <li><a href="#tiempo-presente-cap8">Presente Cap. 8</a></li>
+            <li><a href="#tiempo-pasado-cap8">Pasado Precursor</a></li>
+            <li><a href="#tiempo-futuro-cap8">Futuro Desafiante</a></li>
+        </ul>
+    </nav>
+
+    <main>
+        <article>
+            <section id="tiempo-presente-cap8" class="linea-temporal presente">
+                <h2>Presente: El Primer Paso</h2>
+                <p>
+                    Tras la crucial decisión tomada en la <a href='../lugares/biblioteca_olvidada.html' class='activador-modal tooltip' data-modal-titulo='Biblioteca Olvidada' data-modal-parrafo1='Donde secretos ancestrales fueron revelados.' data-modal-parrafo2='Ahora es un punto de partida para una nueva misión.'>Biblioteca Olvidada<span class='tooltip-texto'>El lugar de la revelación.</span></a>, <a href='../personajes/heroe_principal.html' class='activador-modal tooltip' data-modal-titulo='Elara' data-modal-parrafo1='Cargando con el peso del conocimiento y una nueva determinación.'>Elara<span class='tooltip-texto'>La protagonista.</span></a> y <a href='../personajes/silas_archivista.html' class='activador-modal tooltip' data-modal-titulo='Silas, el Archivista' data-modal-parrafo1='El erudito que ha decidido acompañar o guiar a Elara.' data-modal-parrafo2='Su conocimiento es invaluable en esta nueva etapa.'>Silas<span class='tooltip-texto'>El guardián del saber.</span></a> se ponen en marcha. (El grado de compañía de Silas puede variar: podría acompañarla físicamente, o haberle dado instrucciones precisas y un medio para contactarlo).
+                </p>
+                <p>
+                    Si su decisión fue buscar otro artefacto (otro "Corazón de Cronos"), se describe el inicio de su viaje hacia <a href='../lugares/nuevo_lugar_cap8.html' class='activador-modal tooltip' data-modal-titulo='[Nombre del Nuevo Lugar]' data-modal-parrafo1='Un lugar legendario o recién descubierto que alberga otro artefacto.' data-modal-parrafo2='El viaje estará lleno de peligros.'>[NUEVO LUGAR POR DEFINIR]<span class='tooltip-texto'>El próximo destino.</span></a>. Se enfrentan a peligros iniciales: el terreno es traicionero, antiguas guardianes o bestias corrompidas por ecos temporales. Elara utiliza sus crecientes habilidades con su artefacto, y Silas (o sus enseñanzas) provee el conocimiento para superar estos obstáculos.
+                </p>
+                <p>
+                    Si, en cambio, decidieron prepararse para un enfrentamiento con <a href='../personajes/kael.html' class='activador-modal tooltip' data-modal-titulo='Kael' data-modal-parrafo1='El antagonista cuyos planes deben ser frustrados.'>Kael<span class='tooltip-texto'>El Perseguidor de Sombras.</span></a> basándose en la revelación (ej. explotar una debilidad recién descubierta), los primeros pasos podrían incluir la búsqueda de un material raro necesario para un ritual o un dispositivo, o el intento de contactar a un <a href='../personajes/nuevo_contacto_cap8.html' class='activador-modal tooltip' data-modal-titulo='[Nombre del Nuevo Contacto]' data-modal-parrafo1='Una figura enigmática que podría poseer la clave para ayudar contra Kael.' data-modal-parrafo2='¿Aliado, mercenario o sabio oculto?'>[NUEVO CONTACTO POR DEFINIR]<span class='tooltip-texto'>Un posible aliado.</span></a>, quizás un viejo conocido de Silas o alguien mencionado en los textos de la Biblioteca.
+                </p>
+                <p>
+                    La sección culmina con el encuentro con el primer obstáculo significativo de este nuevo camino, o su llegada al <a href='../lugares/nuevo_lugar_cap8.html' class='activador-modal tooltip' data-modal-titulo='[Nombre del Nuevo Lugar]' data-modal-parrafo1='El primer hito en su nueva misión.'>[NUEVO LUGAR POR DEFINIR]<span class='tooltip-texto'>El próximo destino.</span></a> y la interacción inicial con el <a href='../personajes/nuevo_contacto_cap8.html' class='activador-modal tooltip' data-modal-titulo='[Nombre del Nuevo Contacto]' data-modal-parrafo1='Un personaje clave encontrado en el nuevo lugar o camino.'>[NUEVO CONTACTO POR DEFINIR]<span class='tooltip-texto'>Un nuevo personaje.</span></a>. Este contacto podría ser amistoso, hostil o ambiguo.
+                </p>
+                <p class="navegacion-seccion"><a href="#tiempo-pasado-cap8">Siguiente: Pasado Precursor</a> | <a href="#tiempo-futuro-cap8">Saltar a: Futuro Desafiante</a></p>
+            </section>
+
+            <section id="tiempo-pasado-cap8" class="linea-temporal flashback">
+                <h2>Pasado Precursor: Ecos del Camino</h2>
+                <p>
+                    Un flashback relevante al camino específico elegido por Elara y Silas.
+                </p>
+                <p>
+                    Si viajan a un <a href='../lugares/nuevo_lugar_cap8.html' class='activador-modal tooltip' data-modal-titulo='[Nombre del Nuevo Lugar]' data-modal-parrafo1='Este lugar tiene su propia historia y peligros.'>[NUEVO LUGAR POR DEFINIR]<span class='tooltip-texto'>El próximo destino.</span></a>, el flashback podría mostrar la historia de ese lugar: cómo se formó, quién lo habitó, por qué es importante o peligroso. O podría narrar la historia de alguien que hizo un peregrinaje similar en el pasado, quizás <a href='../personajes/ancestro_elara.html' class='activador-modal tooltip' data-modal-titulo='Aerion el Guardián' data-modal-parrafo1='Pudo haber recorrido sendas similares o enfrentado desafíos parecidos.'>Aerion<span class='tooltip-texto'>El Guardián original.</span></a>, o incluso un joven Silas.
+                </p>
+                <p>
+                    Si se están preparando contra <a href='../personajes/kael.html' class='activador-modal tooltip' data-modal-titulo='Kael' data-modal-parrafo1='Conocer su pasado es clave para derrotarlo.'>Kael<span class='tooltip-texto'>El Perseguidor de Sombras.</span></a>, el flashback podría mostrar una instancia donde las tácticas de Kael fueron contrarrestadas con éxito por otros en el pasado, o un momento en que subestimó a un oponente aparentemente más débil, revelando una posible vulnerabilidad o un patrón de comportamiento.
+                </p>
+                <p class="navegacion-seccion"><a href="#tiempo-presente-cap8">Volver al Presente</a> | <a href="#tiempo-futuro-cap8">Siguiente: Futuro Desafiante</a></p>
+            </section>
+
+            <section id="tiempo-futuro-cap8" class="linea-temporal premonicion">
+                <h2>Futuro Desafiante: La Siguiente Prueba</h2>
+                <p>
+                    Una visión del próximo gran desafío que Elara y Silas (y otros posibles compañeros) enfrentarán como resultado directo de sus acciones en el presente de este capítulo.
+                </p>
+                <p>
+                    Si encontraron un <a href='../personajes/nuevo_contacto_cap8.html' class='activador-modal tooltip' data-modal-titulo='[Nombre del Nuevo Contacto]' data-modal-parrafo1='Las alianzas pueden ser complejas.'>[NUEVO CONTACTO POR DEFINIR]<span class='tooltip-texto'>Un nuevo personaje.</span></a>, la visión podría mostrar una prueba de lealtad impuesta por este, o el peligro que este nuevo contacto representa o al que se enfrenta (y que podría arrastrar a Elara).
+                </p>
+                <p>
+                    Si llegaron a un <a href='../lugares/nuevo_lugar_cap8.html' class='activador-modal tooltip' data-modal-titulo='[Nombre del Nuevo Lugar]' data-modal-parrafo1='Cada lugar guarda sus propios peligros.'>[NUEVO LUGAR POR DEFINIR]<span class='tooltip-texto'>El próximo destino.</span></a>, la visión podría revelar un guardián formidable (físico o mágico) o un puzzle ambiental complejo que deben resolver para progresar.
+                </p>
+                <p>
+                    La visión también podría incluir un indicio de cómo <a href='../personajes/kael.html' class='activador-modal tooltip' data-modal-titulo='Kael' data-modal-parrafo1='Siempre acechando, siempre adaptándose.'>Kael<span class='tooltip-texto'>El Perseguidor de Sombras.</span></a> o sus agentes están un paso adelante, o cómo están reaccionando a las acciones de Elara, intensificando la sensación de urgencia.
+                </p>
+                <p class="navegacion-seccion"><a href="#tiempo-presente-cap8">Volver al Presente</a> | <a href="#tiempo-pasado-cap8">Revisitar: Pasado Precursor</a></p>
+            </section>
+        </article>
+    </main>
+
+    <footer>
+        <p>Fin del Capítulo 8. El camino se vuelve más claro, pero también más peligroso.</p>
+        <p><a href="../index.html">Volver al Índice</a> | <a href="capitulo7.html">Capítulo Anterior</a> | <a href="capitulo9.html">Siguiente Capítulo (Próximamente)</a></p>
+    </footer>
+
+    <!-- El Modal Genérico (copiado para funcionalidad en esta página) -->
+    <div id="miModal" class="modal-contenedor">
+        <div class="modal-contenido">
+            <span class="modal-cerrar">&times;</span>
+            <h2>Título del Modal</h2>
+            <p>Contenido de ejemplo...</p>
+            <p>Más contenido aquí si es necesario.</p>
+        </div>
+    </div>
+    <script src="../js/interacciones.js"></script>
+</body>
+</html>

--- a/lugares/canon_susurrante.html
+++ b/lugares/canon_susurrante.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>El Cañón Susurrante - Novela Multidimensional</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body>
+    <header>
+        <h1>El Cañón Susurrante</h1>
+        <p><a href="../index.html">Volver al Índice</a></p>
+    </header>
+    <main>
+        <section id="descripcion_general" class="descripcion-general">
+            <h2>Descripción General</h2>
+            <p>Una garganta profunda y ventosa, tallada en la roca a lo largo de milenios. Las paredes del cañón están llenas de extrañas formaciones y cuevas. Se llama 'Susurrante' debido a los extraños ecos y el constante silbido del viento que parece llevar voces o advertencias.</p>
+        </section>
+        <section id="mapa_ubicacion" class="mapa-ubicacion">
+            <h2>Mapa y Ubicación</h2>
+            <p>Se extiende por varias leguas, marcando una frontera natural entre las tierras conocidas alrededor de la Aldea del Inicio y las regiones más salvajes y yermas del este. El acceso es difícil y a menudo requiere guías experimentados.</p>
+            <!-- Ejemplo: <img src="../media/mapas/mapa_canon_susurrante.png" alt="Mapa del Cañón Susurrante"> -->
+        </section>
+        <section id="historia_relevancia" class="historia-relevancia">
+            <h2>Historia y Relevancia en la Trama</h2>
+            <p>Una antigua ruta de paso, ahora casi olvidada y considerada peligrosa. Las leyendas dicen que el cañón mismo es una entidad viva o que está imbuido de espíritus ancestrales que reaccionan a la intenciones de quienes lo cruzan. Pudo haber sido un lugar sagrado o una frontera natural defendida en tiempos de la Guerra Olvidada. Se rumorea que oculta secretos o peligros para aquellos que no conocen sus caminos o no muestran el debido respeto.</p>
+        </section>
+        <section id="eventos_ocurridos" class="eventos-ocurridos">
+            <h2>Eventos Clave Ocurridos Aquí</h2>
+            <ul>
+                <li>Vigilado durante generaciones por la familia de <a href="../personajes/guardian_paso.html" class="activador-modal tooltip" data-modal-titulo="Roric, Guardián del Cañón" data-modal-parrafo1="Un individuo hosco y curtido que conoce cada secreto del cañón." data-modal-parrafo2="Su linaje ha protegido este paso durante eras.">Roric<span class="tooltip-texto">Guardián actual.</span></a>.</li>
+                <li>Punto de paso o desafío para <a href="../personajes/heroe_principal.html" class="activador-modal tooltip" data-modal-titulo="Elara" data-modal-parrafo1="Debe cruzar o investigar el cañón como parte de su viaje." data-modal-parrafo2="Los peligros del cañón pondrán a prueba sus habilidades.">Elara<span class="tooltip-texto">La protagonista.</span></a> y <a href="../personajes/silas_archivista.html" class="activador-modal tooltip" data-modal-titulo="Silas, el Archivista" data-modal-parrafo1="Acompaña a Elara, aportando su conocimiento." data-modal-parrafo2="Podría encontrar pistas o peligros en el cañón.">Silas<span class="tooltip-texto">El erudito.</span></a> (mencionado en <a href="../historias/capitulo8.html#tiempo-presente-cap8">Capítulo 8, Presente</a>).</li>
+                <li>Posibles intentos de <a href="../personajes/kael.html" class="activador-modal tooltip" data-modal-titulo="Kael" data-modal-parrafo1="El antagonista podría haber buscado algo en el cañón o intentado corromper a sus guardianes." data-modal-parrafo2="Su influencia oscura podría estar presente.">Kael<span class="tooltip-texto">El Perseguidor de Sombras.</span></a> o sus agentes de atravesarlo o explotar sus energías en el pasado.</li>
+            </ul>
+        </section>
+        <section id="personajes_asociados" class="personajes-asociados">
+            <h2>Personajes Asociados al Lugar</h2>
+            <ul>
+                <li><a href="../personajes/guardian_paso.html" class="activador-modal tooltip" data-modal-titulo="Roric, Guardián del Cañón" data-modal-parrafo1="Su protector y el que mejor conoce sus secretos y peligros." data-modal-parrafo2="Su familia ha vigilado el cañón por generaciones.">Roric, Guardián del Cañón<span class="tooltip-texto">Guardián actual.</span></a> (Guardián actual)</li>
+                <li><a href="../personajes/heroe_principal.html" class="activador-modal tooltip" data-modal-titulo="Elara" data-modal-parrafo1="Necesita atravesar el cañón en su búsqueda." data-modal-parrafo2="El cañón representa un desafío significativo.">Elara<span class="tooltip-texto">Viajera.</span></a> (Viajera)</li>
+                <li><a href="../personajes/silas_archivista.html" class="activador-modal tooltip" data-modal-titulo="Silas, el Archivista" data-modal-parrafo1="Acompaña a Elara, buscando conocimiento incluso en lugares peligrosos." data-modal-parrafo2="Podría estar interesado en las leyendas del cañón.">Silas, el Archivista<span class="tooltip-texto">Viajero erudito.</span></a> (Viajero)</li>
+            </ul>
+        </section>
+        <section id="flora_fauna_recursos" class="flora-fauna-recursos">
+            <h2>Flora, Fauna y Recursos</h2>
+            <p>Vegetación escasa y resistente adaptada a los vientos constantes y la aridez del terreno rocoso. Podría haber criaturas únicas que habitan sus cuevas y grietas (murciélagos gigantes de eco agudo, lagartos de roca que se mimetizan con el entorno, arañas tejedoras de trampas en las sombras). Los 'recursos' podrían ser hierbas raras con propiedades acústicas o medicinales especiales, o cristales que resuenan con los susurros del cañón, utilizados por los guardianes para predecir cambios en el viento o la presencia de intrusos.</p>
+        </section>
+    </main>
+    <footer>
+        <p><small>&copy; 2024 Novela Multidimensional - Descripción de Lugar</small></p>
+        <p><a href="../index.html">Volver al Índice</a></p>
+    </footer>
+
+    <!-- El Modal Genérico (copiado para funcionalidad en esta página) -->
+    <div id="miModal" class="modal-contenedor">
+        <div class="modal-contenido">
+            <span class="modal-cerrar">&times;</span>
+            <h2>Título del Modal</h2>
+            <p>Contenido de ejemplo...</p>
+            <p>Más contenido aquí si es necesario.</p>
+        </div>
+    </div>
+    <script src="../js/interacciones.js"></script>
+</body>
+</html>

--- a/personajes/guardian_paso.html
+++ b/personajes/guardian_paso.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Perfil de Roric, Guardián del Cañón - Novela Multidimensional</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body>
+    <header>
+        <h1>Roric, Guardián del Cañón Susurrante</h1>
+        <p><a href="../index.html">Volver al Índice</a></p>
+    </header>
+    <main>
+        <section id="descripcion_general" class="descripcion-general">
+            <h2>Descripción General</h2>
+            <p>Un individuo hosco y curtido, Roric ha vigilado el Cañón Susurrante durante incontables estaciones. Conoce cada piedra y cada eco del lugar, y es escéptico con los forasteros, pero posee un código de honor.</p>
+        </section>
+        <section id="historia_trasfondo" class="historia-trasfondo">
+            <h2>Historia y Trasfondo</h2>
+            <p>Descendiente de una larga línea de guardianes que protegían un antiguo secreto o un camino sagrado que atraviesa el Cañón Susurrante. Su familia podría haber tenido lazos con la orden de Aerion o haber sido simplemente protectores independientes de su territorio, transmitiendo el deber de generación en generación.</p>
+        </section>
+        <section id="habilidades" class="habilidades">
+            <h2>Habilidades y Conocimientos</h2>
+            <p>Experto en supervivencia en terrenos áridos y montañosos. Gran habilidad con la lanza o el arco. Conocimiento profundo de los peligros naturales y sobrenaturales del Cañón Susurrante, incluyendo sus criaturas y extraños fenómenos acústicos. Puede interpretar señales y augurios del viento o de la tierra.</p>
+        </section>
+        <section id="relaciones" class="relaciones">
+            <h2>Relaciones</h2>
+            <ul>
+                <li><a href="../personajes/heroe_principal.html" class="activador-modal tooltip" data-modal-titulo="Elara" data-modal-parrafo1="Viajera que busca paso o información a través del Cañón Susurrante." data-modal-parrafo2="Su interacción con Roric será determinante.">Elara<span class="tooltip-texto">Encuentro inicial.</span></a> (Encuentro inicial; posible aliada o simple transeúnte)</li>
+                <li><a href="../personajes/silas_archivista.html" class="activador-modal tooltip" data-modal-titulo="Silas, el Archivista" data-modal-parrafo1="El erudito que acompaña a Elara. Podría reconocer el linaje o propósito de Roric." data-modal-parrafo2="Su conocimiento podría facilitar la comunicación.">Silas, el Archivista<span class="tooltip-texto">Acompañante de Elara.</span></a> (Podría reconocer su linaje o propósito)</li>
+                <li>Agentes de <a href="../personajes/kael.html" class="activador-modal tooltip" data-modal-titulo="Kael" data-modal-parrafo1="Kael o sus agentes podrían haber intentado cruzar o corromper el Cañón en el pasado." data-modal-parrafo2="Roric los considera una amenaza directa a su territorio y deber.">Kael<span class="tooltip-texto">Amenaza conocida.</span></a> (Enemigos recurrentes o una amenaza conocida)</li>
+            </ul>
+        </section>
+        <section id="objetos_clave" class="objetos-clave">
+            <h2>Objetos Clave</h2>
+            <p>Un antiguo medallón de guardián, transmitido por sus ancestros, que podría tener alguna propiedad protectora o simbólica. Un mapa detallado tallado en cuero de las rutas seguras y los peligros del Cañón Susurrante. Una lanza con punta de obsidiana, perfectamente equilibrada y mortal en sus manos.</p>
+        </section>
+        <section id="apariciones" class="apariciones">
+            <h2>Apariciones en Historias</h2>
+            <ul>
+                <li><a href="../historias/capitulo8.html#tiempo-presente-cap8">Capítulo 8: El Camino Elegido y Sus Primeras Pruebas</a> (Encuentro en el Cañón Susurrante, como parte de [NUEVO LUGAR POR DEFINIR] o [NUEVO CONTACTO POR DEFINIR] en la planificación del Cap. 8)</li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p><small>&copy; 2024 Novela Multidimensional - Perfil de Personaje</small></p>
+        <p><a href="../index.html">Volver al Índice</a></p>
+    </footer>
+
+    <!-- El Modal Genérico (copiado para funcionalidad en esta página) -->
+    <div id="miModal" class="modal-contenedor">
+        <div class="modal-contenido">
+            <span class="modal-cerrar">&times;</span>
+            <h2>Título del Modal</h2>
+            <p>Contenido de ejemplo...</p>
+            <p>Más contenido aquí si es necesario.</p>
+        </div>
+    </div>
+    <script src="../js/interacciones.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Este commit introduce la estructura y el contenido de marcador de posición para el Capítulo 8, "El Camino Elegido y Sus Primeras Pruebas". También añade un nuevo personaje guardián y un nuevo lugar de paso o desafío.

Cambios principales:
- Creación de `historias/capitulo8.html` con secciones para el presente (Elara y Silas emprenden su nueva misión, encuentro con Roric en el Cañón Susurrante), pasado (contexto del camino elegido) y futuro (visión del próximo desafío).
- Creación del nuevo archivo de personaje `personajes/guardian_paso.html` (Roric, Guardián del Cañón).
- Creación del nuevo archivo de lugar `lugares/canon_susurrante.html`.
- Actualización de `historias/capitulo7.html` para enlazar secuencialmente al Capítulo 8.
- Integración de activadores de modales en el Capítulo 8 y en las nuevas páginas de personaje y lugar.
- Inclusión de la estructura del modal y el script JS en las nuevas páginas HTML.