### PR TITLE
Add Dialogues for Chapter 2 Key Scenes

### DIFF
--- a/plot_outlines/chapter2_dialogues.md
+++ b/plot_outlines/chapter2_dialogues.md
@@ -1,0 +1,32 @@
+# Diálogos del Capítulo 2: Susurros en la Oscuridad
+
+## I. Interacción de Elara con Kaelen (Corresponde a Sección II del Esquema)
+
+Elara: (Con voz apenas un susurro, acercándose al anciano Kaelen que talla madera en el umbral de su choza) "Anciano Kaelen, ¿puedo... puedo hablar con usted un momento? Es... importante."
+Kaelen: (Levantando la vista, sus ojos nublados por los años pero aún agudos. Deja el cuchillo y la madera a un lado.) "Elara. Te veo agitada, niña. Acércate. ¿Qué nube ensombrece tu semblante?"
+Elara: (Traga saliva, sus manos aferrando con fuerza un bulto oculto bajo su chal) "Es que... encontré algo. En las ruinas del Mirador del Este. Algo... antiguo." (Duda, luego saca con renuencia el Orbe de los Ecos Perdidos. Es opaco y frío en la luz del día.) "Tenía estos símbolos... no los reconozco."
+Kaelen: (Se inclina hacia adelante, sus ojos entrecerrándose mientras examina el Orbe. No lo toca.) "Extraño... ciertamente antiguo. Los símbolos..." (Murmura para sí mismo, recorriendo los grabados con la mirada.) "No son de nuestra gente. Hay ecos aquí... ecos que duermen desde hace mucho."
+Elara: "¿Ecos? ¿Qué quiere decir?"
+Kaelen: (Suspira, una sombra cruzando su rostro) "Hay historias, niña, fragmentos de ellas que los más viejos apenas recordamos. Historias de la Guerra Olvidada... de artefactos que trajeron tanto poder como desolación. Se dice que algunos aún guardan... susurros de ese tiempo. Poderes que es mejor no despertar." (Mira a Elara con seriedad.) "Este objeto... tiene la marca de esa era. Siento una... quietud peligrosa en él."
+Elara: (Siente un escalofrío recorrerla a pesar del calor del día) "Peligrosa... ¿Pero qué debo hacer? Siento que... que no puedo simplemente ignorarlo."
+Kaelen: "La sabiduría no siempre reside en la acción, sino a veces en la prudencia, Elara. Algunas puertas es mejor dejarlas cerradas. No te digo que lo destruyas, pues no sé si tal cosa es posible o sabia. Pero ten cuidado. Los ecos del pasado pueden ser ensordecedores para quienes los escuchan demasiado de cerca." (Vuelve a su talla, pero sus manos están quietas y su mirada perdida en la distancia.)
+
+## II. Interacción Inicial de Elara con Lyra (Corresponde a Sección V del Esquema)
+
+Elara: (Avanzando con cautela por el sendero marchito, el aire pesado y los susurros apenas audibles. Se detiene al ver una figura encorvada junto a un árbol retorcido, casi mimetizada con el entorno.) "¿Hola? ¿Hay alguien ahí?"
+Lyra: (Su voz es como el crujir de hojas secas, girándose lentamente. Su rostro está surcado de arrugas, sus ojos brillan con una luz extrañamente penetrante desde debajo de una capucha hecha de pieles y hojas.) "Algunos siempre están aquí. Otros, como tú, son traídos por vientos de cambio... o de necesidad." (Sus ojos se fijan en Elara, una mirada que parece atravesarla.) "Y algunos llevan consigo… una carga tan ruidosa."
+Elara: (Retrocede un paso, su mano instintivamente yendo hacia el Orbe oculto.) "¿Ruidosa? No sé a qué se refiere."
+Lyra: (Una sonrisa apenas perceptible juega en sus labios.) "No lo sabes, ¿o no quieres saberlo? Cuando las raíces lloran, el árbol ya está enfermo. ¿No has oído su lamento en el viento que te ha traído hasta mi puerta?"
+Elara: (Confundida y asustada, pero también extrañamente atraída por la seguridad en la voz de la anciana.) "El sendero... está muriendo. Y oigo... cosas."
+Lyra: "La tierra siente los primeros temblores de la fiebre. Y tú, niña, llevas contigo una canción que pocos pueden oír. Una canción de creación y de olvido." (Da un paso hacia Elara, sus ojos fijos en el lugar donde Elara esconde el Orbe.) "El eco de una estrella caída... o de su sombra. He sentido su despertar. Ya he visto cómo las sombras se alargan en los barrancos donde antes jugaban los niños del sol."
+Elara: (Con un nudo en la garganta) "¿Quién... quién es usted? ¿Sabe qué es esto?" (Un atisbo de esperanza en su voz.)
+Lyra: "Soy Lyra. Solo una oyente de los susurros del mundo. Y sí, niña... empiezo a saber lo que llevas. Y temo por ti, y por lo que ese despertar significa."
+
+## III. Advertencia de Lyra y Consecuencias de la Emboscada (Corresponde a Sección VI del Esquema)
+
+Elara: (Jadeando, apoyada contra un árbol mientras la última de las sombras de los Hounds se disipa. La luz del Orbe aún pulsa débilmente en su mano, caliente al tacto. Mira a Lyra, que se presiona una mano en el brazo, donde la ropa está rasgada y oscura.) "Eso... eso fue el Orbe. Yo no... no lo controlé."
+Lyra: (Asiente con gravedad, sus ojos penetrantes fijos en Elara. Su voz es tensa.) "Pocos pueden controlar los ecos primordiales, niña. Tuviste suerte de que su grito los ahuyentara." (Examina su brazo brevemente antes de volver su atención a Elara.) "Pero no te engañes. Esas... cosas... son solo los carroñeros. Lo que los envió sabe que el Orbe está contigo ahora. Su despertar ha sido notado, como una campana en la quietud de la noche."
+Elara: (El miedo la atenaza de nuevo, más frío esta vez porque es un miedo comprendido.) "¿Lo que los envió? ¿Hay... más?"
+Lyra: "Siempre hay más cuando se trata de la Sombra." (Se acerca a Elara, su mirada urgente.) "Tu viaje a Auca Patricia ya no es solo una búsqueda de conocimiento. Es una carrera. La última vez que algo así despertó en Auca Patricia, la ciudad se convirtió en las ruinas que ves hoy, y sus gritos aún resuenan en las piedras si sabes escuchar. Cada paso hacia esas ruinas te acerca más al corazón de la Sombra que ya ha comenzado a extender sus zarcillos."
+Elara: (Con voz temblorosa pero con una nueva y sombría determinación en sus ojos.) "Entonces... debo llegar antes que ellos. Debo entender qué es esto... y cómo usarlo. ¿Me ayudará?"
+Lyra: "Te guiaré hacia las ruinas, niña. Pero lo que encuentres allí, y cómo lo uses... eso dependerá de tu fuerza, y de tu capacidad para escuchar la canción correcta del Orbe, no sus ecos de desesperación. Debemos partir al alba. La noche ya no es segura para ti, y el tiempo corre en nuestra contra."


### PR DESCRIPTION
This commit introduces a new file, `plot_outlines/chapter2_dialogues.md`, containing drafted dialogues for key interaction points within the Chapter 2 outline ("Susurros en la Oscuridad").

The new file includes dialogues for:
1.  Elara's unsettling conversation with the elder Kaelen about the discovered Orb and its potential dangers (corresponds to Section II of the outline).
2.  Elara's first encounter with the enigmatic hermit Lyra, including Lyra's insightful and ominous observations about the Orb and the encroaching darkness (corresponds to Section V of the outline).
3.  The critical exchange between Lyra and Elara following the ambush by the Hounds of Shadow, where Lyra delivers a stark warning about the noticed awakening of the Orb and the increased dangers of Elara's journey to Auca Patricia (corresponds to Section VI of the outline).

These dialogues aim to:
- Further flesh out the personalities and voices of Elara, Kaelen, and Lyra.
- Provide concrete examples of character interactions described in the plot outline.
- Enhance the emotional depth and narrative tension of Chapter 2.

The dialogues have been reviewed for consistency, clarity, and impact, and are intended to serve as a richer resource for further story development.