### PR TITLE
Draft Chapter 3 Outline: Auca Patricia y la Verdad Fracturada

### DIFF
--- a/plot_outlines/chapter3_outline.md
+++ b/plot_outlines/chapter3_outline.md
@@ -1,0 +1,127 @@
+# Capítulo 3: Auca Patricia y la Verdad Fracturada - Esquema Detallado
+
+## Tema del Capítulo y Conflicto Central (Corresponde a Etapa 2 del Arco: "Los Hilos que se Deshacen")
+*   **Tema:** La desestabilización de la realidad percibida y la búsqueda de la verdad en un mundo de ecos y engaños. Elara se enfrenta a la fragilidad de la historia y la memoria, y comienza a vislumbrar la naturaleza artificial de su mundo.
+*   **Conflicto Central:** Elara, guiada por Lyra, explora las ruinas de Auca Patricia. El Orbe la sumerge en "Ecos de lo No Elegido" cada vez más complejos y contradictorios, desafiando su percepción de la historia. Descubre las primeras pistas de que su realidad podría ser una construcción ("El Engaño del Tejedor"). Mientras tanto, la Sombra Inminente, como agente de "La Sinfonía del Silencio", intenta activamente impedir su progreso y "deshacer" el conocimiento que busca, manifestando su poder de borrar y silenciar la realidad.
+
+## I. El Sendero Menguante – Viaje al Borde de la Comprensión
+
+*   **Setting and Atmosphere:** El viaje desde el bosque hacia las cercanías de Auca Patricia. El paisaje se vuelve progresivamente más extraño y opresivo. Colores desaturados, sonidos anturalmente apagados, flora distorsionada o "incompleta". Una sensación de irrealidad y la impresión de que el mundo pierde su solidez y coherencia.
+*   **Key Events and Plot Progression:**
+    *   Elara y Lyra avanzan. Elara nota con creciente alarma los efectos del "deshacer" de la Sombra en el entorno: parches de bosque donde los colores se han drenado a grises casi monocromáticos, un silencio неестественный donde antes había vida animal (el canto de los pájaros se apaga abruptamente, el susurro de las hojas se vuelve un mero roce seco). Las plantas muestran formas incompletas, como si partes de ellas hubieran sido "borradas" de la existencia.
+    *   Durante una noche, Elara experimenta breves e involuntarias fugas sensoriales a través del Orbe (que lleva oculto pero que parece vibrar sutilmente): ve el camino tal como debió ser hace eras, vibrante y lleno de vida, solo para que la visión se desvanezca y la devuelva a la desoladora realidad. Estas visiones son fugaces, como un parpadeo en su percepción, aumentando su confusión.
+*   **Character Interactions:**
+    *   Elara expresa su miedo y desorientación a Lyra, preguntando si el mundo se está volviendo loco o si es ella.
+    *   Lyra permanece mayormente impasible ante las distorsiones, aunque con una gravedad sombría. Ofrece comentarios crípticos como "El Silencio roba los colores primero, luego las canciones" o "Aquí la Canción del Mundo se desafina, sus notas se pierden." Utiliza pequeñas hierbas o amuletos para crear breves "burbujas" de normalidad sensorial a su alrededor cuando los efectos son muy intensos, acciones que Elara observa con una mezcla de asombro y temor.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** Visiones fugaces e involuntarias de Elara, mostrando el mismo lugar en diferentes estados temporales o de "realidad," sugiriendo que lo que percibe no es la única versión. El Orbe ("Seed of the First Song") actúa como un resonador pasivo a la "tensión" de la realidad.
+    *   **El Engaño del Tejedor:** Lyra alude a la "Canción del Mundo" y su "desafinación," un primer indicio de una estructura subyacente. La forma en que la naturaleza se "deshace" no es simple podredumbre, sino una pérdida de información y complejidad, como si un diseño original se estuviera borrando o corrompiendo.
+    *   **La Sinfonía del Silencio:** Los efectos ambientales son la manifestación directa de la Sombra como agente del Silencio, "deshaciendo" la realidad, borrando su vitalidad, complejidad y coherencia sensorial.
+*   **Elara's Internal Reactions and Development:**
+    *   Su inquietud inicial se transforma en un miedo más profundo y existencial. Comienza a dudar seriamente de la fiabilidad de su propia percepción y de la estabilidad del mundo.
+    *   Crece su dependencia de Lyra como la única que parece entender o navegar esta irrealidad. Se aferra a la presencia de Lyra como un ancla.
+*   **Lyra's Role:** Guía, protectora sutil, e intérprete críptica de los fenómenos. Sus acciones y palabras refuerzan la idea de que lo que está sucediendo va más allá de una simple corrupción física y toca la esencia misma de la realidad.
+
+## II. Llegada a Auca Patricia – Ciudad de Susurros y Piedras Silenciosas
+
+*   **Setting and Atmosphere:** Las ruinas de Auca Patricia. Vastas, antiguas, imponentes, pero con una atmósfera de vacío y silencio неестественный que va más allá de la mera desolación. Se percibe una opresión sutil, y en algunos lugares, una quietud tan profunda que parece absorber el sonido. Las ruinas mismas parecen inestables a la vista, con contornos que a veces tiemblan o se desdibujan.
+*   **Key Events and Plot Progression:**
+    *   Elara y Lyra llegan a las afueras de Auca Patricia. El Orbe en el morral de Elara comienza a vibrar con una intensidad nueva y caótica, emitiendo un leve y bajo zumbido que solo Elara parece percibir plenamente.
+    *   Establecen un refugio oculto y seguro dentro de las ruinas menos expuestas, en una cámara subterránea parcialmente intacta que Lyra parece conocer. Lyra advierte a Elara que la ciudad es un laberinto de "ecos muertos, verdades rotas y silencios hambrientos."
+*   **Character Interactions:**
+    *   Elara está abrumada por la escala de las ruinas y la palpable sensación de tragedia y silencio неестественный. El zumbido del Orbe le produce náuseas y una creciente jaqueca. Expresa su malestar a Lyra, cuestionando la naturaleza de la reacción del Orbe.
+    *   Lyra se mueve con cautela pero con conocimiento, señalando áreas de particular "perturbación," "resonancia caótica," o "silencio absoluto," que deben evitar.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** El Orbe capta innumerables fragmentos de Ecos que se manifiestan para Elara como susurros superpuestos en lenguas olvidadas, el clangor distante de una batalla inexistente, el llanto de un niño fantasmal que parece surgir de las propias piedras. Ve imágenes espectrales superpuestas en las ruinas: un mercado bullicioso donde ahora solo hay piedras caídas, una torre intacta que es solo un montón de escombros, figuras translúcidas que recorren caminos borrados por el tiempo.
+    *   **El Engaño del Tejedor:** Lyra comenta: "Esta ciudad no solo fue construida, fue *cantada* en su inicio. Ahora, su canción está fragmentada, casi silenciada, sus notas perdidas en el tiempo o borradas." El diseño de ciertas estructuras centrales, incluso en ruinas, muestra una simetría y complejidad que sugiere un plan maestro más allá de lo ordinario, con patrones que Elara empieza a reconocer vagamente de sus primeras, caóticas visiones del Orbe.
+    *   **La Sinfonía del Silencio:** El silencio dominante de Auca Patricia es opresivo. Algunas áreas son tan silenciosas que Elara siente que sus propios pensamientos se ahogan, una manifestación del poder de la Sombra para "borrar" incluso la conciencia.
+*   **Elara's Internal Reactions and Development:**
+    *   Asombro mezclado con un terror creciente. La magnitud de la tarea la abruma. El mundo se siente cada vez más como un sueño febril.
+    *   Comienza a entender que el Orbe es una llave a algo mucho más complejo y peligroso que simples visiones del pasado; es una conexión a la inestabilidad fundamental de lo que ella creía que era la historia.
+*   **Lyra's Role:**
+    *   Guía experta en este entorno peligroso y engañoso. Intenta preparar a Elara para la naturaleza desorientadora de los Ecos de la ciudad, enseñándole a discernir entre los "ecos persistentes" y las "trampas del Silencio."
+    *   En respuesta a la angustia de Elara por las vibraciones del Orbe, Lyra podría decir: *"No temas su fuerza, niña, sino su confusión actual. Es antiguo, un corazón arrancado de la Primera Canción. Toda gran melodía, toda existencia, nace de una única y potente semilla de sonido. Esta... recuerda la tierra de donde brotó, y anhela que su canto florezca de nuevo."* (Foreshadowing "Seed of the First Song").
+
+## III. La Biblioteca de las Contradicciones – Primera Inmersión Profunda en los "Ecos"
+
+*   **Setting and Atmosphere:** Un sector específico de Auca Patricia, quizás unas ruinas que sugieren haber sido una biblioteca, un scriptorium o un archivo central. Polvo, piedras caídas, pero una extraña sensación de conocimiento perdido y verdades silenciadas. El aire aquí es particularmente denso con susurros y fluctuaciones visuales.
+*   **Key Events and Plot Progression:**
+    *   Lyra guía a Elara a este lugar, indicando que es un "nexo de Ecos discordantes" o "un punto donde las hebras del pasado se enredaron y rompieron."
+    *   Elara, siguiendo la intensa pulsación del Orbe, interactúa con un objeto clave (un pedestal de lectura dañado, un mural con símbolos extraños, un nicho donde Lyra sugiere que alguna vez hubo un artefacto de conocimiento).
+    *   Es arrastrada a su primera experiencia de Eco compleja y prolongada:
+        *   **Eco Contradictorio 1 (La Decisión Pacífica):** Ve una asamblea de eruditos o líderes de Auca Patricia en su apogeo, debatiendo sobre un gran descubrimiento o una amenaza externa. Se toma una decisión basada en la sabiduría, la paz o la cautela. La escena es vibrante, los personajes definidos, la arquitectura del lugar está intacta y resplandeciente.
+        *   **Eco Contradictorio 2 (La Decisión Hostil):** De repente, la misma escena se "rebobina" o "parpadea" violentamente. Los mismos eruditos, en el mismo lugar, pero sus personalidades parecen más sombrías, sus argumentos más agresivos o desesperados. Toman una decisión bélica, egoísta o imprudente que conduce a un desastre insinuado dentro del Eco (gritos, fuego, la llegada de una oscuridad que comienza a "deshacer" los bordes de la visión).
+        *   Dentro de estos Ecos, Elara nota los extraños símbolos del Orbe brillando en las paredes o en los ropajes de los antiguos, y por instantes, la "realidad" del Eco parece temblar, revelando fugazmente patrones geométricos de luz, como si viera los "hilos" de esa realidad particular.
+*   **Character Interactions:**
+    *   Elara emerge del Eco temblando, profundamente perturbada y confundida, quizás con náuseas o un dolor de cabeza intenso. Le cuenta a Lyra lo que vio, su voz llena de incredulidad. "¿Cuál era real? ¿Cómo pueden existir dos pasados para el mismo momento? ¿O eran... posibilidades?"
+    *   Lyra escucha con atención, luego explica que Auca Patricia fue un lugar donde "muchas realidades posibles lucharon por existir" o donde "la Gran Canción fue interrumpida y reescrita varias veces, dejando ecos de todas sus versiones."
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** La experiencia central. Elara no ve un pasado, sino *posibles* pasados, o versiones alternativas de eventos, desafiando su concepto de historia lineal y verdad única.
+    *   **El Engaño del Tejedor:** Los símbolos recurrentes y los breves destellos de la "subestructura" de la realidad del Eco son las primeras pistas directas de un mundo diseñado. La idea de una "Gran Canción reescrita" apunta a los Tejedores. El "glitch" o "rebobinado" del Eco se siente artificial.
+    *   **La Sinfonía del Silencio:** El desastre insinuado en el segundo Eco podría ser la llegada de una forma temprana de la Sombra, borrando esa "versión" de la historia o "silenciando" esa posibilidad.
+*   **Elara's Internal Reactions and Development:**
+    *   Su comprensión de la "verdad" y la "historia" se hace añicos. Siente una profunda desconfianza hacia lo que el Orbe le muestra, pero también una necesidad imperiosa de entender su funcionamiento y propósito.
+    *   Nace la sospecha de que las fuerzas que actúan sobre su mundo son mucho más complejas que un simple "mal" contra un "bien." La historia misma parece ser un campo de batalla.
+*   **Lyra's Role:** Confirma que los Ecos no son simples. No da respuestas directas, sino que guía a Elara con preguntas y metáforas que la empujan a cuestionar la naturaleza de la realidad. ("¿Y si cada canción puede tener múltiples arreglos, niña? ¿Algunos armoniosos, otros... rotos y olvidados?")
+
+## IV. Patrones en el Deshacer – Buscando la Firma del Tejedor
+
+*   **Setting and Atmosphere:** Diferentes sectores de Auca Patricia, algunos más decrépitos y "silenciosos" que otros. Elara está más alerta, buscando activamente anomalías, ahora con una incipiente comprensión de que busca algo más allá de simples ruinas.
+*   **Key Events and Plot Progression:**
+    *   Elara, con Lyra, busca sistemáticamente los símbolos y patrones geométricos que vio en los Ecos. Los encuentra en lugares extraños: ocultos bajo escombros, en cimientos expuestos donde la piedra parece неестественно perfecta, o en mosaicos donde los patrones parecen cambiar sutilmente cuando no se los mira directamente, como si la propia percepción luchara por fijarlos.
+    *   El Orbe la guía, vibrando con más fuerza cerca de estos "puntos de firma." Al tocar uno, no entra en un Eco narrativo completo, sino que experimenta una visión más abstracta y breve: vastas redes de luz interconectadas, la sensación de una mente o mentes colosales ordenando el caos en patrones armoniosos, y quizás una voz incorporea o una impresión conceptual que susurra palabras como "Diseño," "Contención," "Equilibrio," "Armonía," o "El Tejido debe sostenerse."
+*   **Character Interactions:**
+    *   Elara comparte estas visiones abstractas con Lyra, luchando por describirlas. "¿Eran... los creadores del mundo?"
+    *   Lyra asiente con solemnidad. "Son las cicatrices de la Creación," dice, o "Los hilos con los que se tejió el primer amanecer. Algunos los llaman Tejedores, otros, los Arquitectos de la Canción Primigenia."
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** Las visiones abstractas son Ecos de la *creación* o *mantenimiento* de la realidad misma, no de eventos dentro de ella. Son como vislumbrar el "código fuente" o el "telar" en acción.
+    *   **El Engaño del Tejedor:** Esta es la sección donde Elara recibe las pistas más fuertes sobre la realidad construida. Los símbolos, los patrones, las visiones de "hilos de luz" y las palabras como "Diseño" o "Tejido" apuntan directamente a los Tejedores y su obra.
+    *   **La Sinfonía del Silencio:** Algunos de estos patrones o símbolos están dañados, corroídos de una forma que no es natural (como piedra "deshecha" o "silenciada" energéticamente), como si una fuerza estuviera tratando de "borrarlos" o "deshacerlos," mostrando la oposición del Silencio al Diseño de los Tejedores. Elara podría sentir una "nota sorda" donde el Orbe debería resonar.
+*   **Elara's Internal Reactions and Development:**
+    *   El asombro se mezcla con un pavor cósmico. La idea de que su mundo es "diseñado" o "tejido" por entidades casi divinas es abrumadora y la hace sentir increíblemente pequeña e insignificante.
+    *   Comienza a ver el Orbe no solo como una ventana, sino como una posible herramienta o clave relacionada con esta "arquitectura" de la realidad, quizás una parte del "telar" original.
+*   **Lyra's Role:** Confirma las sospechas de Elara sobre los "Tejedores" (o un concepto similar), dándole un nombre a la fuerza detrás de la creación. Empieza a ser ligeramente más directa, viendo que Elara está lista para verdades más profundas y aterradoras.
+
+## V. La Intervención de la Sombra – El Deshacer en Acción
+
+*   **Setting and Atmosphere:** Un lugar crítico en Auca Patricia donde Elara está a punto de hacer un descubrimiento importante (una cámara central con un gran símbolo Tejedor, un nexo de Ecos particularmente potente, o un texto fragmentario que explícitamente menciona la naturaleza del mundo). La atmósfera se vuelve repentinamente más fría, los susurros se vuelven hostiles y directos, y la sensación de "deshacerse" de la realidad se intensifica dramáticamente.
+*   **Key Events and Plot Progression:**
+    *   Mientras Elara intenta descifrar una compleja serie de símbolos o acceder a un Eco particularmente potente y revelador, la Sombra ataca con fuerza y astucia.
+    *   **Interferencia Activa:**
+        *   Un "Susurrador del Silencio" (una Sombra más inteligente y sutil, quizás con forma vagamente humanoide pero hecha de oscuridad y silencio visual) podría aparecer. No ataca físicamente al principio, sino que intenta manipular a Elara con palabras, usando sus dudas y miedos, sugiriendo que la verdad es demasiado horrible, que el Silencio es la única paz verdadera, o que Lyra la está engañando para sus propios fines. Podría mostrarle Ecos falsos o visiones de desesperación para quebrantarla.
+        *   El entorno inmediato comienza a "deshacerse" visiblemente: las inscripciones que Elara lee se borran activamente, las paredes se vuelven transparentes o se disuelven en niebla gris que absorbe el sonido, los caminos desaparecen.
+        *   Sabuesos de la Sombra atacan, pero sus ataques también tienen un efecto de "borrado" o "deshacer" sobre lo que tocan (la piedra se vuelve polvo, el metal se corroe a velocidad неестественная).
+    *   En la desesperación, Elara usa el Orbe instintivamente. En lugar de solo una explosión de luz, logra por un instante crear una pequeña "burbuja" de realidad estable y coherente a su alrededor y de Lyra, donde los efectos de "deshacer" de la Sombra son repelidos. Este esfuerzo la deja exhausta y temblando.
+    *   Lyra combate con sus métodos, quizás usando cantos que "refuerzan" temporalmente el tejido de la realidad local, o usando elementos naturales (hierbas especiales, agua de un manantial oculto) que son antitéticos al "Silencio."
+*   **Character Interactions:**
+    *   Elara y Lyra luchan juntas, combinando la naciente habilidad de Elara con el Orbe y la experiencia de Lyra. La confrontación con el Susurrador del Silencio es una batalla tanto psicológica para Elara como física.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** El Susurrador podría mostrarle a Elara Ecos falsos o Ecos llenos de desesperación para quebrantarla (por ejemplo, un Eco donde Aerion falla miserablemente, o donde la Aldea del Inicio ya ha sido consumida por la Sombra).
+    *   **El Engaño del Tejedor:** La Sombra ataca los "puntos de firma" de los Tejedores, intentando deshacer su obra. La "burbuja de realidad estable" de Elara es un acto rudimentario de "tejer" o "reafirmar la canción" del mundo.
+    *   **La Sinfonía del Silencio:** La Sombra se manifiesta plenamente como una fuerza de "deshacer," "borrar," y "silenciar," no solo de destrucción física. Sus agentes más inteligentes intentan imponer la filosofía del Silencio, la paz de la no-existencia.
+*   **Elara's Internal Reactions and Development:**
+    *   Terror puro, pero también la primera chispa de verdadera agencia contra estas fuerzas cósmicas. El uso instintivo pero más controlado del Orbe la sorprende a sí misma y le da un atisbo de su potencial.
+    *   La manipulación psicológica del Susurrador la obliga a aferrarse a su cordura, a la necesidad de significado y a lo que ha aprendido de Lyra.
+*   **Lyra's Role:** Combatiente experimentada contra el Silencio, protectora, y la que nombra la amenaza de forma más explícita, quizás llamando al Susurrador "Heraldo del Vacío" o "Voz de la Nada."
+
+## VI. Revelación y Huida – El Peso de un Mundo Tejido
+
+*   **Setting and Atmosphere:** Inmediatamente después del clímax del ataque de la Sombra. Las ruinas están más inestables que nunca, con áreas enteras "parpadeando" o disolviéndose. Urgencia por escapar.
+*   **Key Events and Plot Progression:**
+    *   A pesar de la interferencia de la Sombra, Elara (o Lyra, recuperándolo de entre los escombros) logra asegurar o comprender una pieza final de información crucial antes de que se pierda por completo: una inscripción muy dañada en una estructura central que ha resistido parcialmente el ataque, o un Eco final y lúcido que el Orbe le muestra en un último esfuerzo. Este dice algo como: *"Y así los Tejedores urdieron el Diseño desde la Primera Canción, sellando el Caos Primordial y el Silencio Eterno más allá de los Ecos del Mundo. Pero el Silencio siempre aguarda su nota final para deshacer el Tapiz. Solo una Nueva Canción, nacida de la Semilla, puede remendar los hilos rotos."*
+    *   Lyra, viendo que Elara ha vislumbrado esta verdad (o ayudándola a entenderla), la confirma con gravedad y urgencia: "Sí, niña. El mundo es una Canción, un Tapiz tejido por aquellos que vinieron antes, los Tejedores. Y ahora, está amenazado por el Silencio que busca deshacer toda melodía, todo hilo."
+    *   Deben huir de Auca Patricia mientras los agentes de la Sombra se reagrupan o mientras la propia ciudad se vuelve demasiado inestable y amenaza con "borrarse" por completo.
+*   **Character Interactions:**
+    *   Breve pero intensa conversación entre Elara y Lyra donde la verdad fundamental es reconocida. Elara está en shock, Lyra sombría pero resuelta.
+    *   Su escape es tenso, con la sensación de ser perseguidos no solo por criaturas, sino por la propia disolución de la realidad a sus espaldas.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** El último Eco es una "verdad" fundamental sobre la naturaleza del mundo y el conflicto cósmico.
+    *   **El Engaño del Tejedor:** La confirmación explícita (aunque aún no completa en sus detalles) de que la realidad es un "Diseño," un "Tapiz," una "Canción" creada por los "Tejedores" usando una "Primera Canción." Se introduce la idea de la "Semilla" (el Orbe).
+    *   **La Sinfonía del Silencio:** El "Caos Primordial" o el "Silencio Eterno" es nombrado como la amenaza fundamental que los Tejedores contuvieron, y que ahora regresa para "deshacer el Tapiz."
+*   **Elara's Internal Reactions and Development:**
+    *   El shock de la revelación es inmenso. Su mundo ha cambiado para siempre. El miedo persiste, pero ahora está mezclado con la terrible carga de este conocimiento y la comprensión de que el Orbe que porta es mucho más de lo que imaginaba.
+    *   Comienza a entender la verdadera magnitud de lo que está en juego y el posible papel del Orbe como "Nueva Canción" o "Semilla." Su determinación se vuelve más sombría pero más profunda: ya no lucha solo por su aldea, sino por la existencia misma de su realidad.
+*   **Lyra's Role:** Confirma la verdad fundamental, estableciendo las bases para la siguiente etapa del viaje de Elara. Se posiciona como la única que puede guiarla en esta nueva y aterradora realidad.
+*   **Hook para Capítulo 4:** Deben escapar de Auca Patricia, que ahora es demasiado peligrosa y está "marcada" por la Sombra. ¿Adónde irán? ¿Cómo puede Elara aprender a usar el Orbe, la "Semilla de la Nueva Canción," para "remendar los hilos rotos" del mundo? ¿Quiénes eran exactamente los Tejedores, y queda alguno o alguna forma de acceder a su conocimiento original? La Sombra está ahora plenamente consciente de ella y del Orbe, y la cacería se intensificará.
+
+---


### PR DESCRIPTION
This commit introduces the detailed plot outline for Chapter 3, titled "Auca Patricia y la Verdad Fracturada" (Auca Patricia and the Fractured Truth), in the new file `plot_outlines/chapter3_outline.md`.

This chapter is the first to be designed from the ground up with the integrated multidimensional framework ("El Engaño del Tejedor," "Ecos de lo No Elegido," "La Sinfonía del Silencio") and the "Weaver's Gambit" narrative arc in mind.

The outline details:
- Elara and Lyra's journey to the ruins of Auca Patricia, with environmental effects reflecting the Sombra's "unraveling" nature.
- Elara's profound and disorienting experiences with "Ecos de lo No Elegido," which directly challenge her understanding of reality and history.
- The discovery of initial, tangible clues within Auca Patricia that hint at the "Weave" (the constructed nature of reality) and the "Tejedores."
- Lyra's developing role as a knowing, enigmatic guide, including subtle foreshadowing of the Orb's nature as a "Seed of the First Song."
- The Sombra Inminente's strategic interference, with actions that highlight its "unmaking" capabilities.
- Elara's significant character development as she grapples with these revelations, her shifting worldview, internal conflicts, and emerging instincts.
- A climactic discovery and confrontation, leading to a strong hook for Chapter 4.

This outline provides a comprehensive roadmap for writing Chapter 3, ensuring it advances the overarching plot and deepens the unique thematic and narrative complexities of the story.