### PR TITLE
Draft Chapter 4 Outline: The Weaver's Shadow and the Song of Silence

### DIFF
--- a/plot_outlines/chapter4_outline.md
+++ b/plot_outlines/chapter4_outline.md
@@ -1,0 +1,132 @@
+# Capítulo 4: La Sombra del Tejedor y la Canción del Silencio - Esquema Detallado
+
+## Tema del Capítulo y Conflicto Central (Corresponde a Etapa 3 del Arco: "La Firma del Tejedor" e inicio de Etapa 4: "El Himno del Deshacer")
+*   **Tema:** La búsqueda activa de la verdad en una realidad construida, las implicaciones filosóficas de un universo diseñado y la naturaleza insidiosa de una Sombra que ataca el significado mismo.
+*   **Conflicto Central:** Elara, procesando la revelación de que su mundo es un "Tejido", intenta proactivamente entender a los Tejedores y la estructura de su realidad, usando el Orbe de forma más deliberada. Lyra la guía hacia un nuevo destino que promete un conocimiento más profundo. La Sombra Inminente, ahora consciente de la amenaza que Elara representa, se opone a ella de formas más estratégicas y psicológicas, buscando corromper su búsqueda y reforzar la "canción del Silencio".
+
+## I. Secuelas de Auca Patricia – El Peso de un Cielo Tejido
+
+*   **Setting and Atmosphere:** Un refugio oculto y temporal (cueva aislada, arboleda olvidada que Lyra conoce), a varios días de Auca Patricia. El ambiente es sombrío, introspectivo. Elara está visiblemente afectada, más callada y pensativa. Hay una tensión subyacente de paranoia y la sensación de que ningún lugar es verdaderamente seguro o "real".
+*   **Key Events and Plot Progression:**
+    *   Elara se recupera físicamente del enfrentamiento y la huida. Sus sueños están plagados de imágenes de Auca Patricia, los Ecos contradictorios, los símbolos de los Tejedores y la sensación de "deshacerse" de la Sombra.
+    *   Pasa tiempo en silencio, observando el Orbe, que ahora siente diferente, como un ser vivo con un potencial insondable y aterrador.
+*   **Character Interactions:**
+    *   Elara tiene conversaciones profundas y filosóficas con Lyra. Pregunta sobre la naturaleza de los Tejedores ("¿Eran buenos? ¿Por qué harían un mundo tan frágil?"), el propósito del Tejido, y su propio papel ahora que sabe que es una "Semilla."
+    *   Lyra responde con su sabiduría críptica pero ahora más directa, reconociendo la validez de las preguntas de Elara. Podría decir: "Los Tejedores eran poderosos, no necesariamente omniscientes. Tejieron con la materia de los sueños y el eco de la Primera Canción. Toda creación es un riesgo, niña." O sobre el Orbe: "Una Semilla contiene el árbol entero, pero debe encontrar tierra fértil y aprender a crecer contra el viento."
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** Los sueños de Elara son una manifestación de Ecos procesándose en su subconsciente, mezclando recuerdos reales con visiones del Orbe y fragmentos de Auca Patricia.
+    *   **El Engaño del Tejedor:** Las discusiones se centran en la naturaleza del "Tejido", los "Tejedores," y la "Primera Canción," con Lyra usando estas metáforas más abiertamente con Elara.
+    *   **La Sinfonía del Silencio:** El trauma de la Sombra (su capacidad de "deshacer" y el terror existencial que inspira) es una presencia constante en los pensamientos y temores de Elara.
+*   **Elara's Internal Reactions, Decisions, and Development:**
+    *   Pasa del shock inicial a una fase de intensa reflexión y cuestionamiento. La revelación de Auca Patricia la ha cambiado profundamente.
+    *   Comienza a aceptar la idea de un mundo tejido, pero lucha con sus implicaciones para el libre albedrío y el significado.
+    *   Su miedo se transforma en una determinación más sombría y enfocada: debe entender más, debe encontrar respuestas, no solo para salvar su aldea, sino para comprender la naturaleza de su existencia.
+*   **Lyra's Role:** Actúa como ancla filosófica y emocional para Elara. Valida sus preguntas existenciales y la guía suavemente hacia la aceptación de la nueva y extraña realidad, preparándola para los siguientes pasos.
+
+## II. El Nuevo Sendero – Buscando el Eco de los Tejedores
+
+*   **Setting and Atmosphere:** El mismo refugio. Un sentido de propósito emerge gradualmente de la contemplación.
+*   **Key Events and Plot Progression:**
+    *   Elara, impulsada por la inscripción de Auca Patricia sobre la "Nueva Canción" y la "Semilla," y con la ayuda de Lyra, reexamina el diario de Aerion o los fragmentos de conocimiento obtenidos.
+    *   Descubren una pista (un mapa estelar distorsionado en el diario, una referencia a un lugar donde "el Telar del Mundo canta más fuerte," o un lugar que Lyra conoce por antiguas leyendas como un "santuario de los Primeros Cantores"). Este lugar podría ser el "Eco del Silencio" mencionado por Aerion, reinterpretado ahora no como un lugar de nada, sino un lugar de resonancia primordial.
+    *   Deciden que este nuevo destino es el siguiente paso lógico para entender a los Tejedores y el verdadero potencial del Orbe.
+*   **Character Interactions:**
+    *   Elara es más activa en esta decisión, mostrando iniciativa. "Debo saber qué significa esta 'Nueva Canción'. Debo entender por qué Aerion creía que el Orbe era una esperanza."
+    *   Lyra apoya la decisión, quizás revelando que ella misma ha buscado este lugar o ha sabido de su existencia, pero que nunca tuvo la "llave" (el Orbe y Elara) para acercarse de verdad. Advierte que será un viaje peligroso, no solo por la Sombra, sino por la naturaleza misma del lugar, que podría estar "desincronizado" con el tejido normal de la realidad.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** El diario de Aerion, al ser reexaminado con el Orbe cerca, podría revelar capas ocultas de significado o Ecos de Aerion escribiéndolo, quizás con una urgencia o un conocimiento que Elara no apreció antes.
+    *   **El Engaño del Tejedor:** El destino es explícitamente un lugar ligado a los Tejedores o a la estructura fundamental del Tejido. La búsqueda es ahora directamente sobre ellos.
+    *   **La Sinfonía del Silencio:** La necesidad de encontrar este lugar se ve acentuada por la amenaza de la Sombra; si los Tejedores tienen respuestas, estas son vitales para la lucha contra el Silencio.
+*   **Elara's Internal Reactions, Decisions, and Development:**
+    *   Un renovado sentido de propósito, aunque teñido de aprensión. Acepta la responsabilidad que el Orbe ("Semilla") parece imponerle.
+    *   Se mueve de ser una víctima de las circunstancias a ser una investigadora activa de su extraña realidad.
+*   **Lyra's Role:** Confirma la importancia del nuevo destino y se compromete a guiar a Elara, actuando como mentora en esta nueva fase de interrogación de la realidad.
+
+## III. Viaje a Través de una Tierra "Susurrante" – Donde los Ecos Sangran
+
+*   **Setting and Atmosphere:** El viaje hacia el "Eco del Silencio" o "El Telar Olvidado." El paisaje no está tan visiblemente corrupto como el camino a Auca Patricia, pero es sutilmente "erróneo." Hay una cualidad onírica y desorientadora en el entorno: perspectivas que cambian ligeramente, sonidos distorsionados, una sensación constante de *déjà vu* o *jamais vu*. La atmósfera es de baja pero constante tensión psicológica.
+*   **Key Events and Plot Progression:**
+    *   Elara, con la guía de Lyra, intenta usar el Orbe de forma más controlada para "leer" el entorno o investigar anomalías específicas.
+    *   Encuentran lugares donde los Ecos son particularmente fuertes o "sangran" en la realidad actual: un árbol que muestra todas sus estaciones a la vez en un parpadeo, el sonido de una batalla en un campo vacío, la risa de niños donde no hay nadie.
+    *   En uno de estos lugares, Elara experimenta un Eco particularmente vívido y relevante: quizás una visión de un Tejedor solitario y melancólico observando su creación, o un fragmento de la "Guerra Olvidada" desde una perspectiva inesperada que humaniza al "enemigo" de entonces o muestra la ambigüedad moral de las acciones de los Tejedores.
+*   **Character Interactions:**
+    *   Elara discute sus experiencias con los Ecos con Lyra, tratando de interpretarlos. "¿Ese Tejedor... parecía triste? ¿O era una advertencia?"
+    *   Lyra le enseña a Elara técnicas rudimentarias para "anclarse" cuando explora un Eco, para no perderse en él. También le advierte sobre los "Ecos falsos" o "Ecos corruptos" que la Sombra podría intentar sembrar.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** Elara interactúa más deliberadamente con ellos. Aprende que algunos son recuerdos ambientales, otros son posibilidades no realizadas, y otros podrían ser trampas. El Eco del Tejedor melancólico es clave.
+    *   **El Engaño del Tejedor:** El paisaje mismo, con sus sutiles "fallos" o "superposiciones," es una constante manifestación del Tejido. El Eco del Tejedor ofrece una visión directa (aunque aún enigmática) de los creadores.
+    *   **La Sinfonía del Silencio:** La Sombra podría intentar corromper los Ecos que Elara busca, insertando imágenes de desesperación, o tratando de "silenciar" un Eco particularmente revelador justo cuando Elara está a punto de entenderlo. Esto se manifiesta como el Eco distorsionándose, llenándose de estática visual o auditiva, o terminando abruptamente en un vacío.
+*   **Elara's Internal Reactions, Decisions, and Development:**
+    *   Desarrolla una mayor sensibilidad a las "texturas" de la realidad y a la presencia de Ecos. Comienza a discernir patrones o "sabores" en diferentes tipos de Ecos.
+    *   Su miedo se vuelve más matizado, no solo temor a lo monstruoso, sino a la desorientación, a la pérdida de su propia identidad en el mar de posibilidades y a la manipulación de la verdad.
+    *   Crece su determinación de entender a los Tejedores, ya no como figuras míticas, sino como seres con motivaciones y quizás errores.
+*   **Lyra's Role:** Mentora activa en la exploración de los Ecos. Proporciona contexto y herramientas de discernimiento. Su propio pasado o conocimiento sobre los Tejedores podría insinuarse más.
+
+## IV. El Destino Propuesto – El Eco de la Creación (ej. "El Telar Olvidado" o "El Corazón del Eco del Silencio")
+
+*   **Setting and Atmosphere:** La llegada al destino. Un lugar de inmenso poder y extrañeza, donde las leyes normales de la física parecen suspendidas o alteradas. Podría ser una vasta caverna cristalina donde las formaciones cantan, una isla flotante en un mar de nubes, o ruinas que parecen existir en múltiples dimensiones a la vez. El Orbe de Elara resuena con una potencia abrumadora, casi dolorosa, pero también con una extraña armonía.
+*   **Key Events and Plot Progression:**
+    *   Elara y Lyra navegan por el extraño entorno, que podría requerir resolver acertijos basados en la percepción o la manipulación de Ecos menores.
+    *   Descubren una estructura central o un nexo de poder: el "Telar Olvidado" (una colosal máquina de aspecto orgánico y cristalino, ahora inerte), una biblioteca de tablillas de luz pura, o un lugar donde la "Primera Canción" parece resonar de forma audible y tangible.
+    *   Interactuando con este nexo (quizás insertando el Orbe en un receptáculo, o Elara "cantando" en armonía con él), Elara accede a una Revelación Primordial:
+        *   Una visión más completa y coherente de los Tejedores en el acto de la creación, o debatiendo el propósito de su Tejido.
+        *   La verdadera naturaleza de la "Guerra Olvidada" – quizás no una guerra entre facciones, sino una lucha de los Tejedores contra el Silencio Eterno, o un cisma entre los propios Tejedores sobre cómo manejar el Silencio o el Tejido mismo.
+        *   Una pista crucial sobre el origen o la debilidad de la Sombra actual, o sobre lo que se necesita para "remendar el Tapiz" más allá de la simple defensa.
+*   **Character Interactions:**
+    *   Elara y Lyra trabajan juntas para descifrar el entorno y acceder al nexo.
+    *   La Revelación Primordial es una experiencia principalmente para Elara (a través del Orbe), pero Lyra podría presenciar sus efectos o recibir una parte de la información a través de su propia conexión con el lugar.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** El lugar mismo podría ser un vasto "Eco estabilizado" de la era de los Tejedores. La Revelación Primordial es el Eco más significativo hasta ahora.
+    *   **El Engaño del Tejedor:** Este lugar es la "firma" más clara de los Tejedores. Elara ve la "arquitectura" de la realidad, la "notación" de la Primera Canción, o los "planos" del Tejido. Entiende que su mundo fue *compuesto*.
+    *   **La Sinfonía del Silencio:** Podría haber evidencia de cómo el Silencio corrompió o dañó este lugar en el pasado, o cómo los Tejedores lucharon para protegerlo de ser "silenciado."
+*   **Elara's Internal Reactions, Decisions, and Development:**
+    *   Asombro, pavor, y una profunda comprensión intelectual y emocional de la cosmología de su universo.
+    *   Puede sentir una conexión con los Tejedores (empatía por sus luchas, o consternación por sus posibles errores o arrogancia).
+    *   Se da cuenta de que la Sombra no es solo un "monstruo", sino la antítesis de la creación misma, y que la lucha es mucho más antigua y fundamental de lo que imaginaba.
+*   **Lyra's Role:** Actúa como guardiana y facilitadora, ayudando a Elara a soportar y procesar la inmensa energía e información del lugar. Podría revelar que este era el lugar al que siempre estuvo destinada a guiar a un "portador de la Semilla."
+
+## V. La Respuesta Calculada de la Sombra – Un Ataque al Significado y la Memoria
+
+*   **Setting and Atmosphere:** El corazón del "Telar Olvidado" o el nexo de poder, justo cuando Elara está asimilando la Revelación Primordial. La atmósfera cambia bruscamente: la resonancia armónica es invadida por una disonancia helada; la luz se atenúa.
+*   **Key Events and Plot Progression:**
+    *   La Sombra lanza un ataque sofisticado y dirigido, demostrando que ha rastreado a Elara o que este lugar es un objetivo clave para ella.
+    *   Aparece un agente de la Sombra de alto nivel (el Susurrador del Silencio de nuevo, o una nueva entidad como un "Borrador de Ecos" o un "Maestro de la Disonancia"). Este agente no busca solo la destrucción física.
+    *   **Interferencia Específica:**
+        *   Intenta "silenciar" el nexo de poder, corromper las tablillas de luz, o "deshacer" el Telar Olvidado, borrando activamente el conocimiento de los Tejedores.
+        *   Intenta separar a Elara del Orbe o corromper el propio Orbe, llenándolo de Ecos de desesperación o tratando de "apagar" su "Primera Canción."
+        *   Se dirige a Elara psicológicamente, usando la Revelación Primordial para argumentar la futilidad de la existencia, la inevitabilidad del Silencio, o la tiranía/error de los Tejedores. ("¿Ves su obra? Un instante contra la eternidad del Silencio. Un error que debe ser corregido.")
+    *   Elara y Lyra deben luchar no solo para sobrevivir, sino para proteger la integridad del conocimiento que acaban de obtener y la conexión de Elara con el Orbe. Elara, usando su nueva comprensión, podría intentar usar el Orbe de forma más consciente para "cantar" contra la disonancia de la Sombra, proteger un fragmento de información, o encontrar una "falla" en el ataque de la Sombra.
+*   **Character Interactions:**
+    *   Un enfrentamiento directo y tenso con el agente de la Sombra, que es tanto una batalla de voluntades y filosofías como de poder.
+    *   La cooperación entre Elara y Lyra es crucial, combinando el poder naciente de Elara con la experiencia y el conocimiento de Lyra.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** El agente de la Sombra podría intentar forzar a Elara a Ecos donde el Silencio ya ha triunfado, mostrándole la "paz" de la nada.
+    *   **El Engaño del Tejedor:** La Sombra ataca la "firma" más profunda de los Tejedores, su legado y la estructura misma de su creación. Elara defiende el "Diseño."
+    *   **La Sinfonía del Silencio:** El agente de la Sombra es la encarnación de esta filosofía. Su objetivo es la aniquilación del significado, la memoria y la complejidad (la "canción" de la existencia).
+*   **Elara's Internal Reactions, Decisions, and Development:**
+    *   Se enfrenta a la "lógica" del Silencio y debe rechazarla activamente. Esto solidifica su compromiso con la vida y el significado, a pesar de la naturaleza artificial de su mundo.
+    *   Su uso del Orbe es más deliberado, aunque aún no sea experta. Comienza a sentir que puede ser una "Cantora," no solo una portadora.
+    *   El miedo se mezcla con una ira justa contra la fuerza que busca aniquilarlo todo.
+*   **Lyra's Role:** Protege a Elara y combate a la Sombra, pero también observa a Elara, evaluando su crecimiento y su capacidad para manejar el Orbe y la verdad.
+
+## VI. Nueva Carga, Pregunta Inminente – El Camino hacia el Corazón del Himno Silencioso
+
+*   **Setting and Atmosphere:** El "Telar Olvidado" o nexo de poder, dañado pero no completamente destruido. Elara y Lyra han sobrevivido, pero el peligro es más claro que nunca. Una sensación de urgencia y de que se han adentrado en un conflicto mucho mayor.
+*   **Key Events and Plot Progression:**
+    *   Elara y Lyra evalúan la información crucial que lograron salvar o comprender plenamente durante el ataque (por ejemplo, la Sombra no puede destruir la "Primera Canción" directamente, solo sus expresiones o ecos; o hay un "Corazón del Silencio" desde donde la Sombra coordina su "deshacer"; o se enteran de la existencia de otros "Fragmentos de la Primera Canción" u otros posibles aliados/enemigos en el gran juego cósmico).
+    *   Esta información les da una nueva dirección, un objetivo aún más peligroso: quizás buscar otros fragmentos, encontrar una manera de proteger o amplificar la "Primera Canción" del Orbe, o llevar la lucha al "Corazón del Silencio."
+*   **Character Interactions:**
+    *   Elara, aunque agotada, muestra una nueva madurez y resolución. Discute el siguiente paso con Lyra como una compañera en la lucha, no solo como una pupila.
+    *   Lyra podría revelar un fragmento más de su propio pasado o propósito, explicando por qué este nuevo objetivo es tan vital o tan peligroso.
+*   **Manifestation of Multidimensional Concepts:**
+    *   **Ecos de lo No Elegido:** La información salvada podría ser un Eco particularmente resistente, uno que la Sombra no pudo borrar por completo, sugiriendo que algunas verdades o posibilidades son más "fuertes" que otras.
+    *   **El Engaño del Tejedor:** El conocimiento adquirido se refiere a la estructura más profunda del Tejido, sus vulnerabilidades, y las reglas del "juego" entre los Tejedores (o su legado) y el Silencio.
+    *   **La Sinfonía del Silencio:** Entienden que la Sombra no es solo una plaga, sino una fuerza con una estrategia y quizás un "centro" que puede ser confrontado, llevando la narrativa hacia el núcleo de la Etapa 4 ("El Himno del Deshacer").
+*   **Elara's Internal Reactions, Decisions, and Development:**
+    *   El peso de la responsabilidad sobre sus hombros es inmenso. Ya no hay vuelta atrás a la ignorancia.
+    *   Acepta plenamente su papel como portadora del Orbe y como una fuerza activa contra el Silencio. Su miedo no desaparece, pero se subordina a su propósito.
+    *   Comprende que proteger su mundo significa entender y defender el "Tejido" mismo, y quizás incluso participar en su "reparación" o "refuerzo."
+*   **Lyra's Role:** Consejera estratégica y guardiana. Ayuda a Elara a interpretar las implicaciones de lo que han aprendido y a prepararse para el siguiente, aún más peligroso, capítulo de su viaje.
+*   **Hook para Capítulo 5:** Con un nuevo y aterrador entendimiento del conflicto cósmico y un objetivo que las llevará al corazón de la influencia del Silencio (o a buscar los medios para contrarrestarlo directamente), Elara y Lyra se preparan para su misión más peligrosa hasta la fecha. La Sombra, habiendo fracasado en detenerlas, intensificará su caza, y el destino del Tejido pende de un hilo cada vez más delgado.
+
+---


### PR DESCRIPTION
This commit introduces the detailed plot outline for Chapter 4, titled "The Weaver's Shadow and the Song of Silence," in a new file.

This chapter builds directly on the events and revelations of Chapter 3, advancing Elara's understanding of the integrated multidimensional framework ("El Engaño del Tejedor," "Ecos de lo No Elegido," "La Sinfonía del Silencio") and her progression through "The Weaver's Gambit" narrative arc, primarily focusing on Stage 3 ("The Weaver's Signature") and initial movements into Stage 4 ("The Anthem of Unmaking").

The outline details:
- Elara's internal struggle to process the "fractured truth" from Auca Patricia and her shift towards forming hypotheses about her reality.
- Her first intentional efforts to proactively investigate the "Weave" and "Ecos de lo No Elegido" using the Orb ("Seed of the First Song").
- Her grappling with the philosophical and personal implications of a world designed by Weavers.
- The Sombra Inminente's more targeted and intelligent opposition, aimed at "silencing" her search and revealing more about its own nature.
- A journey to a new significant location where further direct evidence or encounters related to the Weavers occur.
- Elara's continued character development, focusing on her evolving agency, new moral considerations, and increasing resilience.
- A climactic revelation or confrontation, leading to a strong hook for Chapter 5.

This outline provides a comprehensive roadmap for writing Chapter 4, ensuring it advances the overarching plot and deepens the unique thematic and narrative complexities of the story.