### PR TITLE
Draft Dialogues for Chapter 3 (Divinely Enhanced)

### DIFF
--- a/plot_outlines/chapter3_dialogues.md
+++ b/plot_outlines/chapter3_dialogues.md
@@ -1,0 +1,76 @@
+# Diálogos del Capítulo 3: Auca Patricia y la Verdad Fracturada
+
+## Escena 1: El Sendero que se Desmorona y el Silencio Conocedor de Lyra
+*Corresponde aproximadamente a las Secciones I ("El Sendero Menguante") y II ("Llegada a Auca Patricia") del esquema del Capítulo 3.*
+
+**(Elara y Lyra avanzan por un sendero donde la corrupción de la Sombra es palpable. El aire es pesado, los colores parecen desvanecerse por momentos y un silencio неестественный se cierne sobre el bosque.)**
+
+**Elara:** (Con voz tensa, señalando un bosquecillo cercano) Lyra, ¿no ves cómo los colores parecen... huir de las hojas aquí? Hace un instante eran verdes, ahora... casi grises. Y el sonido... es como si el bosque entero contuviera la respiración.
+
+**Lyra:** (Observa la zona indicada, su rostro impasible pero sus ojos reflejando una profunda comprensión.) El Silencio tiene muchas formas de anunciarse, niña. Primero roba los colores, luego las canciones. Lo que percibes es el aliento del Vacío sobre el tejido del mundo.
+
+**Elara:** (Se estremece, apretando el bulto donde guarda el Orbe) Pero... ¿por qué? ¿Qué busca esta... Sombra? ¿Esta quietud? Ayer, el arroyo cercano apenas susurraba. Hoy, parece mudo, su lecho casi seco y las piedras sin brillo, como si hubieran olvidado el tacto del agua.
+
+**Lyra:** (Coloca una mano sobre un árbol cuya corteza parece deshilacharse como tela vieja.) Olvidar es una de sus armas. Borrar la memoria de lo que fue, la textura de la vida. Donde la Canción del Mundo se desafina, el Silencio encuentra una grieta por donde entrar. (Hace una pausa, mirando a Elara.) El Orbe que llevas... ¿no sientes cómo vibra en respuesta a esta... ausencia?
+
+**Elara:** Sí, es una vibración fría, incómoda. A veces, cuando cierro los ojos, veo este mismo sendero, pero lleno de luz, de vida... y luego se desvanece. Me hace dudar de lo que ven mis propios ojos. ¿Este camino... es real, Lyra? ¿O es que todo se está volviendo un mal sueño?
+
+**Lyra:** (Retomando la marcha con paso lento pero firme) Lo que es real y lo que es sueño a veces comparten el mismo hilo en el Gran Tapiz, especialmente cuando la Sombra tira de él. Debemos llegar a Auca Patricia. Allí, los ecos de lo que fue y lo que pudo ser son más fuertes... y también los peligros. Mantén el Orbe cerca, pero no dejes que su confusión te ahogue. Aprende a escuchar su verdadera nota.
+
+**(Elara asiente, aunque la confusión y el miedo persisten. Sigue a Lyra, sintiendo que cada paso la aleja más del mundo que conocía y la adentra en un misterio que desafía la razón.)**
+
+## Escena 2: La Biblioteca de las Contradicciones – Ecos de lo que Fue y lo que Pudo Ser
+*Corresponde aproximadamente a la Sección III ("La Biblioteca de las Contradicciones") del esquema del Capítulo 3.*
+
+**(Elara yace en el suelo polvoriento de la ruinosa biblioteca, temblando visiblemente, con los ojos desorbitados. Acaba de salir de una inmersión prolongada y conflictiva en un Eco del Orbe, provocado al tocar un pedestal de piedra erosionado. Lyra está arrodillada a su lado, observándola con calma, esperando.)**
+
+**Elara:** (Jadeando, la voz rota) No... no puede ser. Lyra, lo que vi... ¡eran dos historias! En el mismo lugar, con la misma gente... pero tomaron decisiones opuestas. En una, había paz, un acuerdo. La ciudad florecía. (Se agarra la cabeza.) Pero luego... todo parpadeó, como un tapiz mal tejido donde los hilos se soltaran y se volvieran a anudar de otra forma. Vi... vi la guerra. La misma asamblea, las mismas caras, pero sus voces eran duras, sus corazones llenos de miedo. ¡Y condujo a la destrucción! Lo sentí... el fuego, los gritos... los símbolos en las paredes parecían sangrar luz...
+
+**Lyra:** (Asiente lentamente, sus ojos profundos como pozos.) Respira, niña. Lo que el Orbe te muestra no es una simple crónica del pasado lineal. Auca Patricia es un lugar donde muchas canciones se cruzaron, donde muchos futuros posibles lucharon por ser la única melodía que resonara en el Telar del Tiempo.
+
+**Elara:** (Se incorpora con dificultad, mirando a Lyra con desesperación.) ¿Posibles? ¿Quieres decir que... que ninguna de las dos era la Verdad? ¿O que ambas lo eran de alguna forma retorcida? ¡Pero los Anales de mi aldea hablan de una sola caída de Auca! Una plaga, dicen... ¡no una guerra de facciones ni una paz traicionada! Ni este... este parpadeo entre realidades.
+
+**Lyra:** (Toma una pizca de polvo de las ruinas y la deja escurrirse entre sus dedos.) Los Anales de tu aldea, como todas las historias contadas por una sola voz, son un solo hilo arrancado de un vasto e intrincado Tejido. Un hilo que una vez fue fuerte, pero que el tiempo y el olvido – y quizás otras manos – han deshilachado o simplificado. El Orbe, esta Semilla de la Primera Canción que portas, resuena con todos los hilos, incluso los que se rompieron, los que nunca se tejieron completamente en el Patrón que conoces, o los que fueron deliberadamente arrancados.
+
+**Elara:** (Con angustia) Entonces... ¿la historia es una mentira? ¿Todo lo que sabemos... todo lo que aprendí del Anciano Kaelen... es solo una de muchas versiones? ¿Una canción elegida entre otras? (La idea la marea.) ¿Quién... quién elige qué canción se canta como verdadera? ¿Los... Tejedores?
+
+**Lyra:** (Su mirada se vuelve distante, como si contemplara algo más allá de las ruinas.) Hubo quienes se llamaron a sí mismos los Arquitectos del Gran Canto, los Tejedores del Diseño. Intentaron urdir una melodía coherente a partir del Silencio Primordial, darle forma a la existencia. Pero incluso ellos no eran omnipotentes, ni estaban siempre unidos en su propósito. Algunos hilos se les escaparon; algunas canciones se negaron a ser silenciadas por completo y resuenan aún como Ecos, como posibilidades persistentes. (Señala un intrincado símbolo a medio borrar en la pared, similar a los del Orbe.) Esta ciudad fue un nudo importante en su Tejido, un lugar donde muchas hebras de posibilidad se encontraron con gran tensión. Aquí, las fronteras entre lo que fue, lo que pudo ser, y lo que quizá aún pugna por ser, son... delgadas como el aliento de un moribundo.
+
+**Elara:** (Observa el símbolo, luego el Orbe en su regazo, que parece vibrar con una nueva y compleja energía, casi como si contuviera todas esas voces y posibilidades a la vez.) ¿Y el Orbe? ¿Por qué me muestra esto? ¿Para volverme loca con verdades que se contradicen?
+
+**Lyra:** (Una leve sonrisa triste.) Para que abras los ojos, niña. Para que entiendas que la realidad es más profunda y más extraña de lo que sueñan los cronistas, incluso los Tejedores en sus momentos de mayor soberbia. El Orbe no te muestra mentiras; te muestra la complejidad de la Verdad, sus múltiples rostros y sus sombras. Te está enseñando a escuchar no solo una nota, sino la sinfonía entera, con todas sus disonancias y armonías ocultas. Te prepara para una canción que solo tú, quizás, puedas llegar a entender... o incluso a cantar para rehacer lo deshecho.
+
+**(Elara mira el Orbe, ya no solo con miedo, sino con una nueva y aterradora forma de respeto. La solidez de su mundo se ha desvanecido, reemplazada por un vertiginoso laberinto de posibilidades. La tarea que tiene por delante parece infinitamente más grande de lo que jamás imaginó.)**
+
+## Escena 3: La Tentación del Susurrador – La Filosofía del Deshacer
+*Corresponde aproximadamente a la Sección V ("La Intervención de la Sombra") del esquema del Capítulo 3.*
+
+**(Elara está a punto de descifrar un complejo mural de símbolos Tejedores en una cámara central de Auca Patricia. El Orbe en su mano brilla con intensidad. De repente, una sección de la pared opuesta parece disolverse en sombras fluidas, y de ellas emerge una figura: el Susurrador del Silencio. No es monstruoso, sino extrañamente sereno, quizás con forma vagamente humanoide pero contornos que se difuminan en la oscuridad, y una voz que es un mero soplo, pero que penetra directamente en la mente.)**
+
+**Susurrador:** (Su voz es un susurro calmo, casi melódico, que parece emanar de todas partes y de ninguna) La pequeña Cantora busca desentrañar los viejos nudos del Tejido. Admirable... y tan fútil. Tanta energía dedicada a preservar lo que anhela el reposo.
+
+**Elara:** (Sobresaltada, retrocede, alzando instintivamente el Orbe, que emite un brillo cálido y protector, y una tenue nota musical defensiva.) ¿Quién eres? ¡Otra de esas... bestias de sombra! ¡Aléjate!
+
+**Susurrador:** (Una ondulación recorre su forma, como una sonrisa hecha de oscuridad) Las bestias son... directas, ruidosas en su afán. Yo prefiero la conversación, la comprensión. Veo tu confusión, niña portadora de la Semilla. Ves las fallas en el Diseño, ¿no es así? Los Ecos rotos, las canciones inacabadas, el sufrimiento inherente a cada hilo de este experimento fallido de los Tejedores.
+
+**Elara:** (Apretando el Orbe, que pulsa con más fuerza, la nota musical haciéndose más clara) Este mundo... tiene belleza. Tiene vida. ¡No es solo sufrimiento ni un experimento! ¡Es real para quienes lo vivimos!
+
+**Susurrador:** ¿Belleza? Una vibración efímera. ¿Vida? Un breve espasmo de consciencia antes del inevitable retorno al origen. **Este Tejido es una fiebre, una ilusión ruidosa y parpadeante nacida del miedo de los Tejedores a la Verdadera Calma, a la inmensidad del Potencial Puro. El Silencio no es vacío, niña; es la libertad de la forma impuesta, el lienzo antes de la primera, dolorosa y limitante pincelada. ¿Por qué aferrarse a una sola, imperfecta y sufriente pintura cuando la beatitud de la no-forma, de todas las posibilidades y ninguna a la vez, aguarda?**
+
+**Lyra:** (Dando un paso al frente, su voz firme aunque tensa, su vara nudosa brillando débilmente con símbolos que parecen afirmarse contra la oscuridad) ¡No la escuches, Elara! Es la Voz del Vacío, el eco de la Desolación que busca apagar toda llama, toda canción. Su paz es la paz de la ceniza.
+
+**Susurrador:** (Se inclina levemente hacia Lyra, con una simulada deferencia) Anciana Guardiana de un Telar raído. Aún te aferras a los hilos rotos y a las melodías gastadas. Pero dime, ¿cuántas veces has remendado lo que anhela deshacerse? ¿Cuántas canciones has intentado salvar del olvido, solo para verlas desvanecerse en el Silencio que es su verdadero hogar?
+
+**Elara:** (El Orbe en su mano parece calentarse, emitiendo una suave melodía casi inaudible, un contrapunto al susurro del ser.) ¡No! Hay... hay algo más que error y sufrimiento. El Orbe me muestra... posibilidades. Creación. La oportunidad de... sanar.
+
+**Susurrador:** (Su forma parece oscurecerse, y el aire alrededor se enfría notablemente, la luz del Orbe pareciendo luchar contra una creciente opresión) Posibilidades de más error, más dolor, más ruido en la perfecta nada. Toda canción termina, niña. ¿Por qué temer la belleza de la quietud final, la elegancia del lienzo en blanco? Vuestros Tejedores os atraparon en una sola nota; nosotros ofrecemos la Sinfonía completa del No-Ser, la libertad de no tener que ser nada en absoluto.
+
+**Elara:** (Temblando, pero su voz gana fuerza, la luz del Orbe intensificándose, su melodía volviéndose más firme y clara) ¡Porque en la canción... hay amor! ¡Hay esperanza! ¡Hay... significado! Aunque sea un significado que debamos tejer nosotros mismos cada día, con cada elección. ¡Tu "paz" es la nada, es el fin de toda posibilidad, de toda historia!
+
+**Lyra:** Bien dicho, niña. El Silencio del que habla no es reposo, es olvido. Es la anulación de toda historia, de toda memoria, el fin de toda canción. Es la anti-música.
+
+**Susurrador:** (Una frialdad emana de él, y las sombras a su alrededor comienzan a extenderse, los contornos de la cámara a "desdibujarse" más rápidamente, la melodía del Orbe encontrando una creciente resistencia) Obstinadas. Aferradas a vuestro pequeño y ruidoso fragmento de existencia. La Madre Silencio es paciente... pero su abrazo es inevitable. Si no venís por voluntad propia a la quietud, la quietud vendrá a reclamaros. Y borrará vuestra terca y diminuta canción del tapiz del universo.
+
+**(Las sombras se profundizan, y de ellas comienzan a materializarse los contornos afilados de los Sabuesos de la Sombra. El Orbe en la mano de Elara brilla ahora con una luz desafiante, y la melodía que emite se vuelve más clara, más fuerte, una afirmación de existencia contra el creciente y opresivo silencio.)**
+
+---


### PR DESCRIPTION
This commit introduces the new file `plot_outlines/chapter3_dialogues.md`, containing key drafted dialogue scenes in Spanish for Chapter 3, "Auca Patricia y la Verdad Fracturada."

These dialogues have been crafted to align with the "divinely enhanced" version of the Chapter 3 outline and the overall multidimensional narrative framework ("The Weaver's Gambit").

The scenes include:
1.  "El Sendero que se Desmorona y el Silencio Conocedor de Lyra": Captures Elara's unease at the "unraveling" environment and Lyra's cryptic, knowing hints about the nature of reality and the Silence.
2.  "La Biblioteca de las Contradicciones – Ecos de lo que Fue y lo que Pudo Ser": Portrays Elara's profound shock when encountering contradictory "Ecos de lo No Elegido" and Lyra's guidance using "divinely enhanced" metaphors (Tejido, Gran Canto, Semilla de la Primera Canción) to explain the multifaceted nature of reality.
3.  "La Tentación del Susurrador – La Filosofía del Deshacer": Features a philosophical confrontation with an articulate agent of Silence (the Susurrador), who presents the seductive logic of Unmaking, which Elara, Lyra, and the Orb's resonance counter.

These dialogues aim to:
- Solidify the voices of Elara and Lyra within the "divinely enhanced" context.
- Introduce the philosophical underpinnings of the Sombra/Silence more directly.
- Convey Elara's intellectual and emotional crisis as she confronts the true nature of her world.
- Enhance the thematic depth and narrative tension of Chapter 3.

This commit marks the completion of all currently planned outlining, "Divine Enhancement" integration, and dialogue drafting tasks for Chapters 2 through the Final Act (Chapter 6), and the dialogue files for Chapters 2 and 3.