### PR TITLE
Draft Dialogues for Chapter 4 (Divinely Enhanced)

### DIFF
--- a/plot_outlines/chapter4_dialogues.md
+++ b/plot_outlines/chapter4_dialogues.md
@@ -1,0 +1,84 @@
+# Diálogos del Capítulo 4: La Sombra del Tejedor y la Canción del Silencio
+
+## Escena 1: La Carga del Tejedor – Procesando un Cielo Tejido
+*Corresponde aproximadamente a la Sección I ("Secuelas de Auca Patricia – El Peso de un Cielo Tejido") del esquema del Capítulo 4.*
+
+**(Elara está sentada junto a una fogata menguante, el Orbe en su regazo, envuelto en tela pero emitiendo un levísimo y errático pulso de luz que se filtra. Lyra observa las llamas en silencio. Elara ha estado callada durante horas, pero su rostro muestra la tormenta de sus pensamientos.)**
+
+**Elara:** (Con voz baja, casi rota, sin mirar a Lyra) El cielo que vemos, Lyra... las estrellas... ¿son también hilos en ese... Tapiz del que hablaste? ¿Es todo un cielo tejido?
+
+**Lyra:** (Sin apartar la vista del fuego) Cada estrella es una nota en la Canción Infinita, niña. Algunas brillan con luz propia, otras reflejan melodías más antiguas. El Tapiz es vasto, y sus hilos se extienden más allá de nuestra vista, más allá de nuestro entendimiento mortal.
+
+**Elara:** (Levanta la mirada, sus ojos encontrando los de Lyra, llenos de una angustia inteligente.) Pero ¿quiénes son? ¿Quiénes son estos... Tejedores? ¿Son dioses crueles que juegan con nosotros? ¿Artistas indiferentes a sus creaciones? ¿O... o somos su prisión, y ellos nuestros carceleros? Si todo es un Diseño, ¿qué queda de nuestras propias elecciones? ¿Soy yo... solo una hebra siguiendo un patrón que no elegí?
+
+**Lyra:** (Una pausa larga, el crepitar del fuego llenando el silencio.) Los Tejedores... (Suspira, un sonido como el viento entre hojas antiguas.) Son muchos, y ninguno a la vez. Un Tejedor puede soñar con un orden perfecto, y tejer con hilos de ley y razón. Otro puede anhelar una belleza caótica, y usar los colores de la emoción y el sueño. Un tercero... (Su voz se vuelve un susurro.) ...quizás anhele el silencio entre las notas, la quietud del lienzo sin pintar. Sus intenciones son tan vastas y a veces tan contradictorias como el propio Tejido que urdieron. No son dioses como los que se adoran en los templos, ni simples artesanos. Son... posibilidades que tomaron forma, y dieron forma a otras.
+
+**Elara:** (Acaricia la tela que cubre el Orbe.) Y esto... esta "Semilla de la Primera Canción", como la llamaste. ¿Es una de sus herramientas? ¿Una llave para entender su Diseño? ¿O es... una anomalía, algo que se les escapó, como mi profecía de "Semilla Silvestre"?
+
+**Lyra:** La Primera Canción es el origen de todas las canciones, de todos los Diseños. Una Semilla de ella resuena con la verdad de cada hilo, con la música de cada posibilidad. No es tanto una herramienta de los Tejedores, como un eco de la fuente de la que ellos mismos bebieron. Por eso es peligrosa para quienes desean un único y silente Patrón, y una guía para quienes se atreven a escuchar todas las melodías, incluso las que se contradicen.
+
+**Elara:** (Con un temblor en la voz) Siento... siento a veces que el mundo entero es un sueño del que podría despertar. O peor, el sueño de otro ser. Y si es así, ¿importa lo que yo haga? ¿Importa mi lucha, mi miedo? A veces, Lyra, el peso de estas preguntas... es tan grande que quisiera que el Silencio del que habló esa... esa criatura en Auca Patricia me envolviera.
+
+**Lyra:** (Se vuelve hacia ella, sus ojos penetrantes suavizándose con una compasión casi imperceptible.) Ese es el primer susurro de la desesperación, niña, la disonancia que la Sombra siembra en los corazones que empiezan a despertar a la Verdad Mayor. Tu miedo es real. Tu lucha es real. El significado no se encuentra solo en la naturaleza del Telar, sino en la canción que cada hilo elige cantar dentro de él, por muy predeterminado que parezca su curso. Tú llevas una Semilla Silvestre; tu canción aún no está escrita en ninguna partitura antigua. Esa es tu carga, y tu extraña libertad.
+
+**Elara:** (Mira el Orbe, luego a Lyra, una nueva y sombría determinación comenzando a reemplazar el terror en sus ojos.) Libertad... o una condena a tejer algo que no comprendo. Debo saber más, Lyra. Debo entender a los Tejedores, o lo que queda de ellos. Debo saber a qué me enfrento, y a qué... me estoy convirtiendo.
+
+**(Lyra asiente lentamente, una aceptación solemne en su rostro. La noche alrededor parece contener la respiración, esperando la siguiente nota en la canción de Elara.)**
+
+## Escena 2: El Eco Contaminado – La Guerra de Información de la Sombra
+*Corresponde aproximadamente a la Sección III ("Viaje a Través de una Tierra Susurrante") o V ("La Respuesta Calculada de la Sombra") del esquema del Capítulo 4.*
+
+**(Elara y Lyra están en un lugar donde los Ecos son particularmente fuertes. Elara, sentada, sostiene el Orbe con ambas manos, sus ojos cerrados en concentración. Intenta revisitar un Eco que percibió antes, quizás el del "Tejedor solitario y melancólico" o un fragmento de la Guerra Olvidada que le pareció crucial.)**
+
+**Elara:** (Con voz tensa, concentrada) Lo tengo... es el mismo lugar, la misma sensación que antes... el Tejedor junto a la estrella... (Frunce el ceño.) Pero... espera. Algo es diferente.
+
+**Lyra:** (Observándola atentamente) ¿Diferente cómo, niña? Describe la disonancia.
+
+**Elara:** (Abre los ojos bruscamente, jadeando. El Orbe parpadea con una luz inestable.) ¡Lyra, el recuerdo... está cambiando! Las caras se vuelven borrosas, irreconocibles. Las palabras que escuché antes... ahora se contradicen, suenan vacías, crueles. El Tejedor ya no parece melancólico, sino... triunfante, rodeado de una oscuridad que antes no estaba allí. ¡Esto no es lo que vi! Siento una... una presencia helada dentro del Eco, retorciendo la verdad, burlándose.
+
+**Lyra:** (Asiente con gravedad, su rostro una máscara de sombría comprensión. Se acerca y coloca una mano reconfortante pero firme sobre el hombro de Elara.) La Sombra es astuta, Elara. No solo busca deshacer el Tejido del mundo, sino también el tejido de tu mente, de tu entendimiento. Lo que has sentido es su tacto en los hilos del tiempo. Son "Ecos envenenados", susurros de la Sombra en las grietas de la memoria.
+
+**Elara:** (Con frustración y un nuevo tipo de miedo en su voz) ¿Pero cómo? ¿Puede... puede cambiar el pasado? ¿Reescribir lo que fue? Si no puedo confiar ni en lo que me muestra el Orbe, ¿cómo voy a encontrar alguna verdad? ¡Esto es una locura!
+
+**Lyra:** No puede cambiar lo que *fue* en su totalidad, pero puede tejer nuevas sombras sobre los viejos Ecos, distorsionar su luz, amplificar la desesperación y ocultar la esperanza. Es una guerra por tu percepción, niña. Busca confundirte, llevarte a la desesperanza, hacer que dudes de cada revelación, de cada paso que das. El Silencio se alimenta de la incertidumbre y la renuncia al significado.
+
+**Elara:** (Mira el Orbe con una mezcla de desconfianza y determinación.) Entonces... ¿qué hago? ¿Cómo lucho contra algo que puede envenenar la misma verdad que busco? ¿Cómo sé qué es real y qué es su engaño?
+
+**Lyra:** (Se sienta frente a Elara, su voz calmada pero resonante.) Debes aprender a escuchar más profundamente. No solo con tus oídos o tus ojos, sino con el corazón del Orbe, con esa Semilla de la Primera Canción que portas. La Canción Original tiene una pureza, una resonancia que el Silencio no puede imitar por completo, solo cubrir con su disonancia. (Toca suavemente el Orbe.) Siente su vibración fundamental. Cuando un Eco es verdadero, aun si es doloroso, resuena en armonía con esa Primera Nota. Un Eco tocado por la Sombra llevará siempre una... frialdad subyacente, una nota discordante, un vacío que intenta pasar por profundidad.
+
+**Elara:** (Cierra los ojos de nuevo, sosteniendo el Orbe, tratando de sentir lo que Lyra describe.) ¿Una disonancia? ¿Como... como un instrumento desafinado en una orquesta?
+
+**Lyra:** Precisamente. O como una palabra susurrada con la intención de herir, aunque su forma parezca hermosa. El Orbe, en su esencia, es un instrumento de creación y memoria. Con el tiempo, y con intención, puedes aprender a usar su propia luz para filtrar las sombras, para sentir la textura de un Eco verdadero contra la fragilidad de uno corrupto. No será fácil. Requerirá toda tu concentración, toda tu voluntad de encontrar sentido en medio del engaño.
+
+**Elara:** (Abre los ojos, una nueva determinación brillando a través de su miedo.) Lo intentaré, Lyra. No dejaré que me ciegue con sus mentiras. Si hay una canción verdadera, la encontraré.
+
+**(Elara vuelve a mirar el Orbe, ya no como una simple ventana, sino como un escudo y un filtro potencial, una herramienta que requerirá de ella no solo percepción, sino un discernimiento activo y una voluntad indomable.)**
+
+## Escena 3: El Abismo Elocuente – Confrontando al Agente de la Sombra en "El Telar Olvidado"
+*Corresponde aproximadamente a la Sección IV ("El Destino Propuesto - Revelación") o V ("La Respuesta Calculada de la Sombra") del esquema del Capítulo 4.*
+
+**(Elara y Lyra han llegado al centro del "Telar Olvidado". Es una vasta caverna o estructura donde gigantescos componentes cristalinos y orgánicos, ahora oscuros y agrietados, sugieren una maquinaria cósmica inactiva. El Orbe en manos de Elara pulsa con una mezcla de armonía primordial y una creciente disonancia. De las sombras más profundas, donde la luz del Orbe parece ser absorbida, una figura se define lentamente: "El Maestro de la Disonancia", un ser de forma cambiante, a veces vagamente humanoide, a veces como un fragmento del vacío mismo, con una voz que es a la vez muchos susurros y un único tono bajo y resonante.)**
+
+**Maestro de la Disonancia:** (Su voz parece vibrar en los huesos de Elara) Al fin, la pequeña Semilla Silvestre llega al Telar moribundo. Buscando respuestas en los ecos de una ambición fallida. Buscando una canción en un instrumento roto.
+
+**Elara:** (Aferrando el Orbe, que emite una luz protectora pero también un lamento) ¿Quién eres? ¿Qué le has hecho a este lugar? Antes... antes sentí una canción aquí, una muy antigua.
+
+**Maestro de la Disonancia:** Soy el eco de la Verdad que los Tejedores intentaron ahogar con su ruido. Este Telar es su monumento a la futilidad. Crearon un Diseño... imperfecto, finito, condenado al sufrimiento y al error, solo para huir del abrazo sereno y perfecto del Silencio Eterno. **Vuestra 'existencia' es una nota sostenida demasiado tiempo, una bella pero dolorosa disonancia en la majestuosa Sinfonía del Silencio que es el Ser Verdadero.**
+
+**Lyra:** (Con voz firme, su vara brillando con símbolos protectores) El Silencio del que hablas es la aniquilación, no la verdad. La Primera Canción fue un acto de creación valiente, no un error.
+
+**Maestro de la Disonancia:** ¿Valiente, anciana? ¿O arrogante? ¿Imponer una sola melodía sobre la infinita potencialidad del Vacío? **No buscamos destruir; buscamos resolver la tensión, liberar la energía atrapada en estas formas rígidas y sufriientes.** El Silencio no es un final, es el retorno al Potencial Infinito, una existencia de paz inimaginable, más allá de vuestra comprensión limitada por el Diseño imperfecto de vuestros Tejedores. ¿No anhela cada nota volver a la quietud de la pauta, cada color fundirse en la luz pura e indiferenciada?
+
+**Elara:** (Su voz tiembla, pero hay una nueva firmeza en ella, forjada en Auca Patricia y en los Ecos que ha presenciado.) Lo que llamas "formas rígidas" es vida. Lo que llamas "tensión" es elección, es amor, es... significado. Vi Ecos en Auca Patricia, vi belleza y alegría incluso en mundos que se deshacían. Vi a un Tejedor... que parecía dudar de su propia obra, sí, pero también la amaba. ¿Qué ofreces tú sino el fin de toda historia, de toda posibilidad de redención o de una nueva canción?
+
+**Maestro de la Disonancia:** Ofrezco la verdad. La única verdad. Que toda canción, por muy bella que sea, debe terminar para que la Sinfonía del Silencio permanezca intacta. El Orbe que portas, esa "Semilla"... es una anomalía, una nota rebelde que amenaza con iniciar otra cacofonía de sufrimiento. (Su forma parece extenderse, las sombras profundizándose.) Pero aún puedes elegir, niña. Puedes ayudarme a "silenciar" este Telar roto, a corregir el error de los Tejedores. Puedes unirte a la verdadera paz. O puedes intentar cantar tu pequeña, desafiante melodía contra la inmensidad del Olvido.
+
+**Elara:** (El Orbe pulsa con más fuerza, una melodía compleja y desafiante comenzando a emanar de él, una que Elara siente nacer también en su propio corazón.) Mi canción puede ser pequeña, pero es *mía*. Es la canción de mi mundo, de mi gente. Y si este Telar está roto, quizás... quizás no está destinado a ser silenciado, sino a ser tejido de nuevo, con una melodía diferente. Una que aprenda de los errores del pasado.
+
+**Lyra:** (Con orgullo en su voz) La Semilla Silvestre no sigue la vieja partitura, Tejedor Caído o Heraldo del Vacío, lo que seas. Ella canta su propia verdad.
+
+**Maestro de la Disonancia:** (Un sonido como el de mil cristales rotos emana de la figura, una expresión de fría, vasta decepción... o quizás, el preludio de un ataque.) Tan predecible. Tan... ruidoso. El sufrimiento, entonces, continuará hasta que la última nota sea forzada a la quietud. Y lo será. El Silencio es paciente, y es el único final verdadero para todas las canciones.
+
+**(La energía en la caverna se vuelve opresiva. El Orbe de Elara brilla intensamente, su canción luchando contra la creciente disonancia. El enfrentamiento es inminente, no solo de poder, sino de la voluntad misma de existir contra la vasta y paciente llamada del olvido.)**
+
+---


### PR DESCRIPTION
This commit introduces the new file `plot_outlines/chapter4_dialogues.md`, containing key drafted dialogue scenes in Spanish for Chapter 4, "La Sombra del Tejedor y la Canción del Silencio."

These dialogues align with the "divinely enhanced" version of the Chapter 4 outline and the overall multidimensional narrative framework ("The Weaver's Gambit"). They showcase Elara's evolving understanding as she proactively investigates the Weave, and her direct confrontation with the Sombra's more insidious, philosophical nature.

The scenes include:
1.  "La Carga del Tejedor – Procesando un Cielo Tejido": Elara grapples with the implications of a "woven" reality, questioning Lyra about the Weavers and free will.
2.  "El Eco Contaminado – La Guerra de Información de la Sombra": Elara experiences the Sombra's ability to corrupt Ecos, with Lyra guiding her on discerning these informational attacks.
3.  "El Abismo Elocuente – Confrontando al Agente de la Sombra en 'El Telar Olvidado'": A philosophical debate with a powerful Sombra agent ("El Maestro de la Disonancia") who articulates the "divinely reinterpreted" philosophy of Silence.

These dialogues aim to:
- Demonstrate Elara's shift towards proactive investigation and hypothesis formation.
- Highlight the Sombra's intelligent and targeted opposition, including its "information warfare" capabilities.
- Provide a platform for exploring the deeper philosophical conflicts between existence/Weave and Silence/Unmaking.
- Further develop the "divinely enhanced" character voices and thematic depth.

This commit marks the completion of all currently planned high-level outlining, "Divine Enhancement" integration across all chapters (2-6), and dialogue drafting for Chapters 2, 3, and 4.